### PR TITLE
update spec file with versio from OBS

### DIFF
--- a/make_dist.sh
+++ b/make_dist.sh
@@ -32,6 +32,6 @@ bin/git-archive-all.sh --prefix $outfile/ \
 		       --verbose \
 		       $outfile.tar
 echo "compressing..."
-bzip2 -9 $outfile.tar
+xz -z9 $outfile.tar
 
 echo "done."


### PR DESCRIPTION
Update to the same version as currently used in OBS project
home:dalgaaf:dovecot-ceph-plugin for SLES12-SP3 and openSUSE
versions: Leap 42.3 and Tumbleweed.

Changed make_dist.sh to build tar.xz

Signed-off-by: Danny Al-Gaaf <danny.al-gaaf@bisect.de>