### PR TITLE
Fixes from SCA

### DIFF
--- a/src/dict-rados/dict-rados.cpp
+++ b/src/dict-rados/dict-rados.cpp
@@ -80,7 +80,7 @@ struct rados_dict {
 };
 
 class DictGuidGenerator : public librmb::RadosGuidGenerator {
-  void generate_guid(std::string *guid) {
+  void generate_guid(std::string *guid) override {
     guid_128_t namespace_guid;
     guid_128_generate(namespace_guid);
     *guid = guid_128_to_string(namespace_guid);

--- a/src/librmb/rados-ceph-config.h
+++ b/src/librmb/rados-ceph-config.h
@@ -20,7 +20,7 @@ namespace librmb {
 
 class RadosCephConfig {
  public:
-  RadosCephConfig(librados::IoCtx *io_ctx_);
+  explicit RadosCephConfig(librados::IoCtx *io_ctx_);
   RadosCephConfig() { io_ctx = nullptr; }
   virtual ~RadosCephConfig() {}
 

--- a/src/librmb/rados-cluster-impl.h
+++ b/src/librmb/rados-cluster-impl.h
@@ -25,18 +25,18 @@ class RadosClusterImpl : public RadosCluster {
   RadosClusterImpl();
   virtual ~RadosClusterImpl();
 
-  int init();
-  int init(const std::string &clustername, const std::string &rados_username);
+  int init() override;
+  int init(const std::string &clustername, const std::string &rados_username) override;
 
   int connect();
-  void deinit();
+  void deinit() override;
 
-  int pool_create(const std::string &pool);
-  int io_ctx_create(const std::string &pool, librados::IoCtx *io_ctx);
-  int get_config_option(const char *option, std::string *value);
+  int pool_create(const std::string &pool) override;
+  int io_ctx_create(const std::string &pool, librados::IoCtx *io_ctx) override;
+  int get_config_option(const char *option, std::string *value) override;
   int dictionary_create(const std::string &pool, const std::string &username, const std::string &oid,
                         RadosDictionary **dictionary);
-  bool is_connected();
+  bool is_connected() override;
   librados::Rados &get_cluster() { return *cluster; }
 
  private:

--- a/src/librmb/rados-dictionary-impl.h
+++ b/src/librmb/rados-dictionary-impl.h
@@ -34,23 +34,23 @@ class RadosDictionaryImpl : public RadosDictionary {
                       const std::string& cfg_object_name_);
   virtual ~RadosDictionaryImpl();
 
-  const std::string get_full_oid(const std::string& key);
-  const std::string get_shared_oid();
-  const std::string get_private_oid();
+  const std::string get_full_oid(const std::string& key) override;
+  const std::string get_shared_oid() override;
+  const std::string get_private_oid() override;
 
-  const std::string& get_oid() { return oid; }
-  const std::string& get_username() { return username; }
-  const std::string& get_poolname() { return poolname; }
+  const std::string& get_oid() override { return oid; }
+  const std::string& get_username() override { return username; }
+  const std::string& get_poolname() override { return poolname; }
 
-  librados::IoCtx& get_io_ctx(const std::string& key);
-  librados::IoCtx& get_shared_io_ctx();
-  librados::IoCtx& get_private_io_ctx();
+  librados::IoCtx& get_io_ctx(const std::string& key) override;
+  librados::IoCtx& get_shared_io_ctx() override;
+  librados::IoCtx& get_private_io_ctx() override;
 
-  void remove_completion(librados::AioCompletion* c);
-  void push_back_completion(librados::AioCompletion* c);
-  void wait_for_completions();
+  void remove_completion(librados::AioCompletion* c) override;
+  void push_back_completion(librados::AioCompletion* c) override;
+  void wait_for_completions() override;
 
-  int get(const std::string& key, std::string* value_r);
+  int get(const std::string& key, std::string* value_r) override;
 
  private:
   bool load_configuration(librados::IoCtx* io_ctx);

--- a/src/librmb/rados-dovecot-ceph-cfg-impl.cpp
+++ b/src/librmb/rados-dovecot-ceph-cfg-impl.cpp
@@ -17,10 +17,7 @@ RadosDovecotCephCfgImpl::RadosDovecotCephCfgImpl(librados::IoCtx *io_ctx_) {
   rados_cfg.set_io_ctx(io_ctx_);
 }
 
-RadosDovecotCephCfgImpl::RadosDovecotCephCfgImpl(RadosConfig &dovecot_cfg_, RadosCephConfig &rados_cfg_) {
-  dovecot_cfg = dovecot_cfg_;
-  rados_cfg = rados_cfg_;
-}
+RadosDovecotCephCfgImpl::RadosDovecotCephCfgImpl(RadosConfig &dovecot_cfg_, RadosCephConfig &rados_cfg_) : dovecot_cfg(dovecot_cfg_), rados_cfg(rados_cfg_) {}
 
 
 int RadosDovecotCephCfgImpl::save_default_rados_config() {

--- a/src/librmb/rados-dovecot-ceph-cfg-impl.h
+++ b/src/librmb/rados-dovecot-ceph-cfg-impl.h
@@ -30,69 +30,69 @@ class RadosDovecotCephCfgImpl : public RadosDovecotCephCfg {
 
   // dovecot config
 
-  const std::string &get_rados_cluster_name() { return dovecot_cfg.get_rbox_cluster_name(); }
-  const std::string &get_rados_username() { return dovecot_cfg.get_rados_username(); }
-  void update_pool_name_metadata(const char *value) { dovecot_cfg.update_pool_name_metadata(value); }
-  const std::string &get_rados_save_log_file() { return dovecot_cfg.get_rados_save_log_file(); }
-  const std::string &get_pool_name_metadata_key() { return dovecot_cfg.get_pool_name_metadata_key(); }
+  const std::string &get_rados_cluster_name() override { return dovecot_cfg.get_rbox_cluster_name(); }
+  const std::string &get_rados_username() override { return dovecot_cfg.get_rados_username(); }
+  void update_pool_name_metadata(const char *value) override { dovecot_cfg.update_pool_name_metadata(value); }
+  const std::string &get_rados_save_log_file() override { return dovecot_cfg.get_rados_save_log_file(); }
+  const std::string &get_pool_name_metadata_key() override { return dovecot_cfg.get_pool_name_metadata_key(); }
 
-  std::string &get_pool_name() { return dovecot_cfg.get_pool_name(); }
+  std::string &get_pool_name() override { return dovecot_cfg.get_pool_name(); }
 
-  std::string &get_key_prefix_keywords() { return dovecot_cfg.get_key_prefix_keywords(); }
-  void update_metadata(const std::string &key, const char *value_) { dovecot_cfg.update_metadata(key, value_); }
+  std::string &get_key_prefix_keywords() override { return dovecot_cfg.get_key_prefix_keywords(); }
+  void update_metadata(const std::string &key, const char *value_) override { dovecot_cfg.update_metadata(key, value_); }
 
-  bool is_ceph_posix_bugfix_enabled() { return dovecot_cfg.is_ceph_posix_bugfix_enabled(); }
+  bool is_ceph_posix_bugfix_enabled() override { return dovecot_cfg.is_ceph_posix_bugfix_enabled(); }
   // rados config
-  bool is_user_mapping() { return rados_cfg.is_user_mapping(); }
-  void set_config_valid(bool is_valid_) {
+  bool is_user_mapping() override { return rados_cfg.is_user_mapping(); }
+  void set_config_valid(bool is_valid_) override {
     dovecot_cfg.set_config_valid(is_valid_);
     if (is_valid_) {
       rados_cfg.set_cfg_object_name(dovecot_cfg.get_rbox_cfg_object_name());
     }
   }
 
-  void set_rbox_cfg_object_name(const std::string &value) { dovecot_cfg.set_rbox_cfg_object_name(value); }
+  void set_rbox_cfg_object_name(const std::string &value) override { dovecot_cfg.set_rbox_cfg_object_name(value); }
 
-  std::map<std::string, std::string> *get_config() { return dovecot_cfg.get_config(); }
-  void set_io_ctx(librados::IoCtx *io_ctx_) { rados_cfg.set_io_ctx(io_ctx_); }
-  int load_rados_config() {
+  std::map<std::string, std::string> *get_config() override { return dovecot_cfg.get_config(); }
+  void set_io_ctx(librados::IoCtx *io_ctx_) override { rados_cfg.set_io_ctx(io_ctx_); }
+  int load_rados_config() override {
     //  return dovecot_cfg.is_config_valid() ? rados_cfg.load_cfg() : -1;
     return rados_cfg.load_cfg();
   }
-  int save_default_rados_config();
-  void set_user_mapping(bool value_) { rados_cfg.set_user_mapping(value_); }
-  void set_user_ns(const std::string &ns) { rados_cfg.set_user_ns(ns); }
-  std::string &get_user_ns() { return rados_cfg.get_user_ns(); }
-  void set_user_suffix(const std::string &ns_suffix) { rados_cfg.set_user_suffix(ns_suffix); }
-  std::string &get_user_suffix() { return rados_cfg.get_user_suffix(); }
-  void set_update_attributes(const std::string &update_attributes_) {
+  int save_default_rados_config() override;
+  void set_user_mapping(bool value_) override { rados_cfg.set_user_mapping(value_); }
+  void set_user_ns(const std::string &ns) override { rados_cfg.set_user_ns(ns); }
+  std::string &get_user_ns() override { return rados_cfg.get_user_ns(); }
+  void set_user_suffix(const std::string &ns_suffix) override { rados_cfg.set_user_suffix(ns_suffix); }
+  std::string &get_user_suffix() override { return rados_cfg.get_user_suffix(); }
+  void set_update_attributes(const std::string &update_attributes_) override {
     rados_cfg.set_update_attributes(update_attributes_);
   }
 
-  bool is_mail_attribute(enum rbox_metadata_key key) { return rados_cfg.is_mail_attribute(key); }
-  bool is_updateable_attribute(enum rbox_metadata_key key) { return rados_cfg.is_updateable_attribute(key); }
-  void update_mail_attributes(const char *value) { rados_cfg.update_mail_attribute(value); }
-  void update_updatable_attributes(const char *value) { rados_cfg.update_updateable_attribute(value); }
-  bool is_update_attributes() { return rados_cfg.is_update_attributes(); }
+  bool is_mail_attribute(enum rbox_metadata_key key) override { return rados_cfg.is_mail_attribute(key); }
+  bool is_updateable_attribute(enum rbox_metadata_key key) override { return rados_cfg.is_updateable_attribute(key); }
+  void update_mail_attributes(const char *value) override { rados_cfg.update_mail_attribute(value); }
+  void update_updatable_attributes(const char *value) override { rados_cfg.update_updateable_attribute(value); }
+  bool is_update_attributes() override { return rados_cfg.is_update_attributes(); }
 
-  const std::string &get_metadata_storage_module() { return rados_cfg.get_metadata_storage_module(); };
-  const std::string &get_metadata_storage_attribute() { return rados_cfg.get_metadata_storage_attribute(); };
+  const std::string &get_metadata_storage_module() override { return rados_cfg.get_metadata_storage_module(); };
+  const std::string &get_metadata_storage_attribute() override { return rados_cfg.get_metadata_storage_attribute(); };
 
-  const std::string &get_mail_attributes_key() { return rados_cfg.get_mail_attribute_key(); }
-  const std::string &get_updateable_attributes_key() { return rados_cfg.get_updateable_attribute_key(); }
-  const std::string &get_update_attributes_key() { return rados_cfg.get_update_attributes_key(); }
+  const std::string &get_mail_attributes_key() override { return rados_cfg.get_mail_attribute_key(); }
+  const std::string &get_updateable_attributes_key() override { return rados_cfg.get_updateable_attribute_key(); }
+  const std::string &get_update_attributes_key() override { return rados_cfg.get_update_attributes_key(); }
 
-  bool is_config_valid() { return dovecot_cfg.is_config_valid() && rados_cfg.is_config_valid(); }
-  const std::string &get_public_namespace() { return rados_cfg.get_public_namespace(); }
+  bool is_config_valid() override { return dovecot_cfg.is_config_valid() && rados_cfg.is_config_valid(); }
+  const std::string &get_public_namespace() override { return rados_cfg.get_public_namespace(); }
   void update_mail_attributes(const std::string &mail_attributes) {
     rados_cfg.update_mail_attribute(mail_attributes.c_str());
   }
   void update_updatable_attributes(const std::string &updateable_attributes) {
     rados_cfg.update_updateable_attribute(updateable_attributes.c_str());
   }
-  int save_object(const std::string &oid, librados::bufferlist &buffer) { return rados_cfg.save_object(oid, buffer); }
-  int read_object(const std::string &oid, librados::bufferlist *buffer) { return rados_cfg.read_object(oid, buffer); }
-  void set_io_ctx_namespace(const std::string &namespace_) { rados_cfg.set_io_ctx_namespace(namespace_); }
+  int save_object(const std::string &oid, librados::bufferlist &buffer) override { return rados_cfg.save_object(oid, buffer); }
+  int read_object(const std::string &oid, librados::bufferlist *buffer) override { return rados_cfg.read_object(oid, buffer); }
+  void set_io_ctx_namespace(const std::string &namespace_) override { rados_cfg.set_io_ctx_namespace(namespace_); }
 
  private:
   RadosConfig dovecot_cfg;

--- a/src/librmb/rados-dovecot-ceph-cfg-impl.h
+++ b/src/librmb/rados-dovecot-ceph-cfg-impl.h
@@ -24,7 +24,7 @@ namespace librmb {
 
 class RadosDovecotCephCfgImpl : public RadosDovecotCephCfg {
  public:
-  RadosDovecotCephCfgImpl(librados::IoCtx *io_ctx_);
+  explicit RadosDovecotCephCfgImpl(librados::IoCtx *io_ctx_);
   RadosDovecotCephCfgImpl(RadosConfig &dovecot_cfg_, RadosCephConfig &rados_cfg_);
   virtual ~RadosDovecotCephCfgImpl(){};
 

--- a/src/librmb/rados-metadata-storage-default.h
+++ b/src/librmb/rados-metadata-storage-default.h
@@ -23,7 +23,7 @@ namespace librmb {
  */
 class RadosMetadataStorageDefault : public RadosStorageMetadataModule {
  public:
-  RadosMetadataStorageDefault(librados::IoCtx *io_ctx_);
+  explicit RadosMetadataStorageDefault(librados::IoCtx *io_ctx_);
   virtual ~RadosMetadataStorageDefault();
   void set_io_ctx(librados::IoCtx *io_ctx_) override { this->io_ctx = io_ctx_; }
 

--- a/src/librmb/rados-metadata-storage-default.h
+++ b/src/librmb/rados-metadata-storage-default.h
@@ -25,17 +25,17 @@ class RadosMetadataStorageDefault : public RadosStorageMetadataModule {
  public:
   RadosMetadataStorageDefault(librados::IoCtx *io_ctx_);
   virtual ~RadosMetadataStorageDefault();
-  void set_io_ctx(librados::IoCtx *io_ctx_) { this->io_ctx = io_ctx_; }
+  void set_io_ctx(librados::IoCtx *io_ctx_) override { this->io_ctx = io_ctx_; }
 
-  int load_metadata(RadosMailObject *mail);
-  int set_metadata(RadosMailObject *mail, RadosMetadata &xattr);
-  bool update_metadata(std::string &oid, std::list<RadosMetadata> &to_update);
-  void save_metadata(librados::ObjectWriteOperation *write_op, RadosMailObject *mail);
+  int load_metadata(RadosMailObject *mail) override;
+  int set_metadata(RadosMailObject *mail, RadosMetadata &xattr) override;
+  bool update_metadata(std::string &oid, std::list<RadosMetadata> &to_update) override;
+  void save_metadata(librados::ObjectWriteOperation *write_op, RadosMailObject *mail) override;
 
-  int update_keyword_metadata(std::string &oid, RadosMetadata *metadata);
-  int remove_keyword_metadata(std::string &oid, std::string &key);
+  int update_keyword_metadata(std::string &oid, RadosMetadata *metadata) override;
+  int remove_keyword_metadata(std::string &oid, std::string &key) override;
   int load_keyword_metadata(std::string &oid, std::set<std::string> &keys,
-                             std::map<std::string, ceph::bufferlist> *metadata);
+                             std::map<std::string, ceph::bufferlist> *metadata) override;
 
  public:
   static std::string module_name;

--- a/src/librmb/rados-metadata-storage-ima.h
+++ b/src/librmb/rados-metadata-storage-ima.h
@@ -34,16 +34,16 @@ class RadosMetadataStorageIma : public RadosStorageMetadataModule {
  public:
   RadosMetadataStorageIma(librados::IoCtx *io_ctx_, RadosDovecotCephCfg *cfg_);
   virtual ~RadosMetadataStorageIma();
-  void set_io_ctx(librados::IoCtx *io_ctx_) { this->io_ctx = io_ctx_; }
-  int load_metadata(RadosMailObject *mail);
-  int set_metadata(RadosMailObject *mail, RadosMetadata &xattr);
-  bool update_metadata(std::string &oid, std::list<RadosMetadata> &to_update);
-  void save_metadata(librados::ObjectWriteOperation *write_op, RadosMailObject *mail);
+  void set_io_ctx(librados::IoCtx *io_ctx_) override { this->io_ctx = io_ctx_; }
+  int load_metadata(RadosMailObject *mail) override;
+  int set_metadata(RadosMailObject *mail, RadosMetadata &xattr) override;
+  bool update_metadata(std::string &oid, std::list<RadosMetadata> &to_update) override;
+  void save_metadata(librados::ObjectWriteOperation *write_op, RadosMailObject *mail) override;
 
-  int update_keyword_metadata(std::string &oid, RadosMetadata *metadata);
-  int remove_keyword_metadata(std::string &oid, std::string &key);
+  int update_keyword_metadata(std::string &oid, RadosMetadata *metadata) override;
+  int remove_keyword_metadata(std::string &oid, std::string &key) override;
   int load_keyword_metadata(std::string &oid, std::set<std::string> &keys,
-                             std::map<std::string, ceph::bufferlist> *metadata);
+                             std::map<std::string, ceph::bufferlist> *metadata) override;
 
  public:
   static std::string module_name;

--- a/src/librmb/rados-metadata-storage-impl.h
+++ b/src/librmb/rados-metadata-storage-impl.h
@@ -33,7 +33,7 @@ class RadosMetadataStorageImpl : public RadosMetadataStorage {
     }
   }
 
-  RadosStorageMetadataModule *create_metadata_storage(librados::IoCtx *io_ctx_, RadosDovecotCephCfg *cfg_) {
+  RadosStorageMetadataModule *create_metadata_storage(librados::IoCtx *io_ctx_, RadosDovecotCephCfg *cfg_) override {
     this->io_ctx = io_ctx_;
     this->cfg = cfg_;
     if (storage == nullptr) {
@@ -48,7 +48,7 @@ class RadosMetadataStorageImpl : public RadosMetadataStorage {
     return storage;
   }
 
-  RadosStorageMetadataModule *get_storage() {
+  RadosStorageMetadataModule *get_storage() override {
     assert(storage != nullptr);
     return storage;
   }

--- a/src/librmb/rados-metadata.h
+++ b/src/librmb/rados-metadata.h
@@ -24,8 +24,7 @@ namespace librmb {
 class RadosMetadata {
  public:
   RadosMetadata() {}
-  RadosMetadata(std::string& key_, std::string& value_) {
-    key = key_;
+  RadosMetadata(std::string& key_, std::string& value_) : key(key_) {
     bl.append(value_);
   }
   RadosMetadata(enum rbox_metadata_key _key, const std::string& val) { convert(_key, val); }

--- a/src/librmb/rados-namespace-manager.h
+++ b/src/librmb/rados-namespace-manager.h
@@ -20,7 +20,7 @@ namespace librmb {
 
 class RadosNamespaceManager {
  public:
-  RadosNamespaceManager(RadosDovecotCephCfg *config_) {
+  explicit RadosNamespaceManager(RadosDovecotCephCfg *config_) {
     this->oid_suffix = "_namespace";
     this->config = config_;
   }

--- a/src/librmb/rados-save-log.h
+++ b/src/librmb/rados-save-log.h
@@ -61,7 +61,7 @@ class RadosSaveLogEntry {
 
 class RadosSaveLog {
  public:
-  RadosSaveLog(const std::string &logfile_) {
+  explicit RadosSaveLog(const std::string &logfile_) {
     this->logfile = logfile_;
     log_active = !logfile.empty();
   }

--- a/src/librmb/rados-save-log.h
+++ b/src/librmb/rados-save-log.h
@@ -21,12 +21,10 @@ namespace librmb {
 class RadosSaveLogEntry {
  public:
   RadosSaveLogEntry() {}
-  RadosSaveLogEntry(const std::string &oid_, const std::string &ns_, const std::string &pool_, const std::string &op_) {
-    this->oid = oid_;
-    this->ns = ns_;
-    this->pool = pool_;
-    this->op = op_;
-  }
+  RadosSaveLogEntry(const std::string &oid_, const std::string &ns_, const std::string &pool_, const std::string &op_) : oid(oid_),
+															 ns(ns),
+															 pool(pool_),
+															 op(op_) {}
   ~RadosSaveLogEntry(){};
 
   friend std::ostream &operator<<(std::ostream &os, const RadosSaveLogEntry &obj) {
@@ -61,8 +59,7 @@ class RadosSaveLogEntry {
 
 class RadosSaveLog {
  public:
-  explicit RadosSaveLog(const std::string &logfile_) {
-    this->logfile = logfile_;
+  explicit RadosSaveLog(const std::string &logfile_) : logfile(logfile_) {
     log_active = !logfile.empty();
   }
   RadosSaveLog() { log_active = false; }

--- a/src/librmb/rados-storage-impl.h
+++ b/src/librmb/rados-storage-impl.h
@@ -28,44 +28,44 @@ class RadosStorageImpl : public RadosStorage {
   explicit RadosStorageImpl(RadosCluster *cluster);
   virtual ~RadosStorageImpl();
 
-  librados::IoCtx &get_io_ctx();
-  int stat_mail(const std::string &oid, uint64_t *psize, time_t *pmtime);
-  void set_namespace(const std::string &_nspace);
-  std::string get_namespace() { return nspace; }
-  std::string get_pool_name() { return pool_name; }
+  librados::IoCtx &get_io_ctx() override;
+  int stat_mail(const std::string &oid, uint64_t *psize, time_t *pmtime) override;
+  void set_namespace(const std::string &_nspace) override;
+  std::string get_namespace() override { return nspace; }
+  std::string get_pool_name() override { return pool_name; }
 
-  int get_max_write_size() { return max_write_size; }
-  int get_max_write_size_bytes() { return max_write_size * 1024 * 1024; }
+  int get_max_write_size() override { return max_write_size; }
+  int get_max_write_size_bytes() override { return max_write_size * 1024 * 1024; }
 
   int split_buffer_and_exec_op(RadosMailObject *current_object, librados::ObjectWriteOperation *write_op_xattr,
-                               const uint64_t &max_write);
+                               const uint64_t &max_write) override;
 
-  int delete_mail(RadosMailObject *mail);
-  int delete_mail(const std::string &oid);
+  int delete_mail(RadosMailObject *mail) override;
+  int delete_mail(const std::string &oid) override;
 
   int aio_operate(librados::IoCtx *io_ctx_, const std::string &oid, librados::AioCompletion *c,
-                  librados::ObjectWriteOperation *op);
-  librados::NObjectIterator find_mails(const RadosMetadata *attr);
-  int open_connection(const std::string &poolname);
-  int open_connection(const std::string &poolname, const std::string &clustername, const std::string &rados_username);
-  void close_connection();
+                  librados::ObjectWriteOperation *op) override;
+  librados::NObjectIterator find_mails(const RadosMetadata *attr) override;
+  int open_connection(const std::string &poolname) override;
+  int open_connection(const std::string &poolname, const std::string &clustername, const std::string &rados_username) override;
+  void close_connection() override;
   bool wait_for_write_operations_complete(
-      std::map<librados::AioCompletion *, librados::ObjectWriteOperation *> *completion_op_map);
+      std::map<librados::AioCompletion *, librados::ObjectWriteOperation *> *completion_op_map) override;
 
-  bool wait_for_rados_operations(const std::vector<librmb::RadosMailObject *> &object_list);
+  bool wait_for_rados_operations(const std::vector<librmb::RadosMailObject *> &object_list) override;
 
-  int read_mail(const std::string &oid, librados::bufferlist *buffer);
+  int read_mail(const std::string &oid, librados::bufferlist *buffer) override;
   int move(std::string &src_oid, const char *src_ns, std::string &dest_oid, const char *dest_ns,
-           std::list<RadosMetadata> &to_update, bool delete_source);
+           std::list<RadosMetadata> &to_update, bool delete_source) override;
   int copy(std::string &src_oid, const char *src_ns, std::string &dest_oid, const char *dest_ns,
-           std::list<RadosMetadata> &to_update);
+           std::list<RadosMetadata> &to_update) override;
 
-  int save_mail(const std::string &oid, librados::bufferlist &buffer);
-  bool save_mail(RadosMailObject *mail, bool &save_async);
-  bool save_mail(librados::ObjectWriteOperation *write_op_xattr, RadosMailObject *mail, bool save_async);
-  librmb::RadosMailObject *alloc_mail_object();
+  int save_mail(const std::string &oid, librados::bufferlist &buffer) override;
+  bool save_mail(RadosMailObject *mail, bool &save_async) override;
+  bool save_mail(librados::ObjectWriteOperation *write_op_xattr, RadosMailObject *mail, bool save_async) override;
+  librmb::RadosMailObject *alloc_mail_object() override;
 
-  void free_mail_object(librmb::RadosMailObject *mail);
+  void free_mail_object(librmb::RadosMailObject *mail) override;
 
  private:
   int create_connection(const std::string &poolname);

--- a/src/librmb/tools/rmb/rmb.h
+++ b/src/librmb/tools/rmb/rmb.h
@@ -22,13 +22,12 @@ namespace librmb {
 
 class RadosMailBox {
  public:
-  RadosMailBox(std::string _mailbox_guid, int _mail_count, std::string _mbox_orig_name) {
-    this->mail_count = _mail_count;
-    this->mailbox_guid = _mailbox_guid;
+  RadosMailBox(std::string _mailbox_guid, int _mail_count, std::string _mbox_orig_name) : mailbox_guid(_mailbox_guid),
+											  mail_count(_mail_count),
+											  mbox_orig_name(_mbox_orig_name) {
     this->mailbox_size = 0;
     this->total_mails = 0;
     this->parser = nullptr;
-    this->mbox_orig_name = _mbox_orig_name;
   }
   virtual ~RadosMailBox() {}
 

--- a/src/storage-rbox/rbox-storage.cpp
+++ b/src/storage-rbox/rbox-storage.cpp
@@ -48,7 +48,7 @@ using std::string;
 
 class RboxGuidGenerator : public librmb::RadosGuidGenerator {
  public:
-  void generate_guid(std::string *guid_) {
+  void generate_guid(std::string *guid_) override {
     guid_128_t namespace_guid;
     guid_128_generate(namespace_guid);
     *guid_ = guid_128_to_string(namespace_guid);


### PR DESCRIPTION
Some common fixes:
- make single argument constructors explicit 
- mark some functions with override
- init some variables in the init list for performance reasons