### PR TITLE
fixes for g++ and clang++ compiler warnings

### DIFF
--- a/src/dict-rados/dict-rados.cpp
+++ b/src/dict-rados/dict-rados.cpp
@@ -9,6 +9,10 @@
  * Foundation.  See file COPYING.
  */
 
+#ifdef HAVE_CONFIG_H
+ #include "dovecot-ceph-plugin-config.h"
+#endif
+
 #include <limits.h>
 
 #include <iostream>
@@ -706,7 +710,7 @@ struct dict_iterate_context *rados_dict_iterate_init(struct dict *_dict, const c
         for (auto k : private_keys) {
           iter->results.emplace_back();
           iter->results.back().key = k;
-#ifdef DOVECOT_CEPH_PLUGINS_HAVE_OMAP_GET_VALS2
+#ifdef DOVECOT_CEPH_PLUGIN_HAVE_OMAP_GET_VALS2
           bool more;
           private_read_op.omap_get_vals2("", k, LONG_MAX, &iter->results.back().map, &more, &iter->results.back().rval);
 #else
@@ -733,7 +737,7 @@ struct dict_iterate_context *rados_dict_iterate_init(struct dict *_dict, const c
         for (auto k : shared_keys) {
           iter->results.emplace_back();
           iter->results.back().key = k;
-#ifdef DOVECOT_CEPH_PLUGINS_HAVE_OMAP_GET_VALS2
+#ifdef DOVECOT_CEPH_PLUGIN_HAVE_OMAP_GET_VALS2
           bool more;
           shared_read_op.omap_get_vals2("", k, LONG_MAX, &iter->results.back().map, &more, &iter->results.back().rval);
 #else

--- a/src/dict-rados/dict-rados.cpp
+++ b/src/dict-rados/dict-rados.cpp
@@ -622,7 +622,7 @@ class kv_map {
   int rval = -1;
   string key;
   std::map<string, bufferlist> map;
-  typename map<string, bufferlist>::iterator map_iter;
+  typename std::map<string, bufferlist>::iterator map_iter;
 };
 
 class rados_dict_iterate_context {

--- a/src/librmb/rados-metadata-storage-ima.cpp
+++ b/src/librmb/rados-metadata-storage-ima.cpp
@@ -36,16 +36,16 @@ int RadosMetadataStorageIma::parse_attribute(RadosMailObject *mail, json_t *root
     value = json_object_iter_value(iter);
 
     if (key.compare(RadosMetadataStorageIma::keyword_key) == 0) {
-      std::string keyword_key;
+      std::string _keyword_key;
       json_t *keyword_value;
       void *keyword_iter = json_object_iter(value);
       while (keyword_iter) {
         librados::bufferlist bl;
-        keyword_key = json_object_iter_key(keyword_iter);
+        _keyword_key = json_object_iter_key(keyword_iter);
         keyword_value = json_object_iter_value(keyword_iter);
         bl.append(json_string_value(keyword_value));
 
-        (*mail->get_extended_metadata())[keyword_key] = bl;
+        (*mail->get_extended_metadata())[_keyword_key] = bl;
 
         keyword_iter = json_object_iter_next(value, keyword_iter);
       }

--- a/src/librmb/rados-util.cpp
+++ b/src/librmb/rados-util.cpp
@@ -8,6 +8,11 @@
  * License version 2.1, as published by the Free Software
  * Foundation.  See file COPYING.
  */
+
+#ifdef HAVE_CONFIG_H
+#include "dovecot-ceph-plugin-config.h"
+#endif
+
 #include "rados-util.h"
 #include <string>
 #include <limits.h>
@@ -95,7 +100,7 @@ int RadosUtils::get_all_keys_and_values(librados::IoCtx *io_ctx, const std::stri
   int err = 0;
   librados::ObjectReadOperation first_read;
   std::set<std::string> extended_keys;
-#ifdef HAVE_OMAP_GET_KEYS_2
+#ifdef DOVECOT_CEPH_PLUGIN_HAVE_OMAP_GET_KEYS_2
   first_read.omap_get_keys2("", LONG_MAX, &extended_keys, nullptr, &err);
 #else
   first_read.omap_get_keys("", LONG_MAX, &extended_keys, &err);

--- a/src/librmb/tools/rmb/rmb.cpp
+++ b/src/librmb/tools/rmb/rmb.cpp
@@ -190,7 +190,7 @@ static void usage(std::ostream &out) {
          "\n";
 }
 
-static void usage_exit() {
+__attribute__((noreturn)) static void usage_exit() {
   usage(std::cerr);
   exit(1);
 }


### PR DESCRIPTION
-Wshadow
- add noreturn attribute
- fix typename
- fix deprecation in rados lib correclty