### PR TITLE
Jrse #182

### DIFF
--- a/src/dict-rados/dict-rados.cpp
+++ b/src/dict-rados/dict-rados.cpp
@@ -10,7 +10,7 @@
  */
 
 #ifdef HAVE_CONFIG_H
- #include "dovecot-ceph-plugin-config.h"
+#include "dovecot-ceph-plugin-config.h"
 #endif
 
 #include <limits.h>
@@ -346,9 +346,6 @@ int rados_dict_lookup(struct dict *_dict, pool_t pool, const char *key, const ch
   return RADOS_COMMIT_RET_NOTFOUND;
 }
 
-static void rados_dict_transaction_private_complete_callback(completion_t comp, void *arg);
-static void rados_dict_transaction_shared_complete_callback(completion_t comp, void *arg);
-
 #define ENORESULT 1000
 
 class rados_dict_transaction_context {
@@ -360,7 +357,6 @@ class rados_dict_transaction_context {
   std::string guid_to_str;
   void *context = nullptr;
   dict_transaction_commit_callback_t *callback;
-
 
   map<string, string> set_map;
   set<string> unset_set;
@@ -403,7 +399,7 @@ class rados_dict_transaction_context {
       return true;
     } else if (!key.compare(0, strlen(DICT_PATH_SHARED), DICT_PATH_SHARED)) {
       dirty_shared = true;
-	  return false;
+      return false;
     }
     i_unreached();
   }
@@ -531,8 +527,6 @@ void rados_dict_set_timestamp(struct dict_transaction_context *_ctx, const struc
 }
 #endif
 
-
-
 void (*transaction_commit)(struct dict_transaction_context *ctx, bool async,
                            dict_transaction_commit_callback_t *callback, void *context);
 
@@ -563,15 +557,15 @@ int rados_dict_transaction_commit(struct dict_transaction_context *_ctx, bool as
       ctx->atomic_inc_not_found ? RADOS_COMMIT_RET_NOTFOUND : (failed ? RADOS_COMMIT_RET_FAILED : RADOS_COMMIT_RET_OK);
   if (callback != nullptr) {
 #if DOVECOT_PREREQ(2, 3)
-      struct dict_commit_result result = {static_cast<dict_commit_ret>(ret), nullptr};  // TODO(p.mauritius): text?
-      callback(&result, ctx->context);
+    struct dict_commit_result result = {static_cast<dict_commit_ret>(ret), nullptr};  // TODO(p.mauritius): text?
+    callback(&result, ctx->context);
 #else
-      callback(ret, ctx->context);
+    callback(ret, ctx->context);
 #endif
-    }
+  }
 
-    delete ctx;
-    ctx = NULL;
+  delete ctx;
+  ctx = NULL;
 
 #if DOVECOT_PREREQ(2, 3)
   return;

--- a/src/librmb/Makefile.am
+++ b/src/librmb/Makefile.am
@@ -19,7 +19,7 @@ headers = \
 	rados-cluster-impl.h \
 	rados-storage-impl.h \
 	rados-dictionary-impl.h \
-	rados-mail-object.h \
+	rados-mail.h \
 	rados-util.h \
 	rados-metadata.h \
 	rados-types.h \
@@ -43,7 +43,7 @@ librmb_la_SOURCES = \
 	rados-cluster-impl.cpp \
 	rados-storage-impl.cpp \
 	rados-dictionary-impl.cpp \
-	rados-mail-object.cpp \
+	rados-mail.cpp \
 	rados-util.cpp \
 	rados-dovecot-config.cpp \
 	rados-namespace-manager.cpp\

--- a/src/librmb/rados-mail-object.cpp
+++ b/src/librmb/rados-mail-object.cpp
@@ -34,20 +34,31 @@ RadosMailObject::~RadosMailObject() {}
 void RadosMailObject::set_guid(const uint8_t *_guid) { memcpy(this->guid, _guid, sizeof(this->guid)); }
 
 std::string RadosMailObject::to_string(const string &padding) {
-  string uid = get_metadata(RBOX_METADATA_MAIL_UID);
-  string recv_time_str = get_metadata(RBOX_METADATA_RECEIVED_TIME);
-  string p_size = get_metadata(RBOX_METADATA_PHYSICAL_SIZE);
-  string v_size = get_metadata(RBOX_METADATA_VIRTUAL_SIZE);
+  string uid;
+  get_metadata(RBOX_METADATA_MAIL_UID, &uid);
+  string recv_time_str;
+  get_metadata(RBOX_METADATA_RECEIVED_TIME, &recv_time_str);
+  string p_size;
+  get_metadata(RBOX_METADATA_PHYSICAL_SIZE, &p_size);
+  string v_size;
+  get_metadata(RBOX_METADATA_VIRTUAL_SIZE, &v_size);
 
-  string rbox_version = get_metadata(RBOX_METADATA_VERSION);
-  string mailbox_guid = get_metadata(RBOX_METADATA_MAILBOX_GUID);
-  string mail_guid = get_metadata(RBOX_METADATA_GUID);
-  string mb_orig_name = get_metadata(RBOX_METADATA_ORIG_MAILBOX);
+  string rbox_version;
+  get_metadata(RBOX_METADATA_VERSION, &rbox_version);
+  string mailbox_guid;
+  get_metadata(RBOX_METADATA_MAILBOX_GUID, &mailbox_guid);
+  string mail_guid;
+  get_metadata(RBOX_METADATA_GUID, &mail_guid);
+  string mb_orig_name;
+  get_metadata(RBOX_METADATA_ORIG_MAILBOX, &mb_orig_name);
 
   // string keywords = get_metadata(RBOX_METADATA_OLDV1_KEYWORDS);
-  string flags = get_metadata(RBOX_METADATA_OLDV1_FLAGS);
-  string pvt_flags = get_metadata(RBOX_METADATA_PVT_FLAGS);
-  string from_envelope = get_metadata(RBOX_METADATA_FROM_ENVELOPE);
+  string flags;
+  get_metadata(RBOX_METADATA_OLDV1_FLAGS, &flags);
+  string pvt_flags;
+  get_metadata(RBOX_METADATA_PVT_FLAGS, &pvt_flags);
+  string from_envelope;
+  get_metadata(RBOX_METADATA_FROM_ENVELOPE, &from_envelope);
 
   time_t ts = -1;
   if (!recv_time_str.empty()) {

--- a/src/librmb/rados-mail-object.h
+++ b/src/librmb/rados-mail-object.h
@@ -33,54 +33,50 @@ class RadosMailObject {
   RadosMailObject();
   virtual ~RadosMailObject();
 
-  void set_oid(const char* _oid) {
-  this->oid = _oid;
-}
-void set_oid(const string& _oid) { this->oid = _oid; }
-void set_guid(const uint8_t* guid);
-void set_mail_size(const uint64_t& _size) { object_size = _size; }
-void set_active_op(bool _active) { this->active_op = _active; }
-void set_rados_save_date(const time_t& _save_date) { this->save_date_rados = _save_date; }
+  void set_oid(const char* _oid) { this->oid = _oid; }
+  void set_oid(const string& _oid) { this->oid = _oid; }
+  void set_guid(const uint8_t* guid);
+  void set_mail_size(const uint64_t& _size) { object_size = _size; }
+  void set_active_op(bool _active) { this->active_op = _active; }
+  void set_rados_save_date(const time_t& _save_date) { this->save_date_rados = _save_date; }
 
-const string& get_oid() { return this->oid; }
-const uint64_t& get_mail_size() { return this->object_size; }
+  const string& get_oid() { return this->oid; }
+  const uint64_t& get_mail_size() { return this->object_size; }
 
-time_t* get_rados_save_date() { return &this->save_date_rados; }
-uint8_t* get_guid_ref() { return this->guid; }
-librados::bufferlist* get_mail_buffer() { return &this->mail_buffer; }
-map<string, ceph::bufferlist>* get_metadata() { return &this->attrset; }
+  time_t* get_rados_save_date() { return &this->save_date_rados; }
+  uint8_t* get_guid_ref() { return this->guid; }
+  librados::bufferlist* get_mail_buffer() { return &this->mail_buffer; }
+  map<string, ceph::bufferlist>* get_metadata() { return &this->attrset; }
 
-map<AioCompletion*, ObjectWriteOperation*>* get_completion_op_map() { return &completion_op; }
+  map<AioCompletion*, ObjectWriteOperation*>* get_completion_op_map() { return &completion_op; }
 
-string get_metadata(rbox_metadata_key key) {
-  string str_key(1, static_cast<char>(key));
-  return get_metadata(str_key);
-}
-
-string get_metadata(const string& key) {
-  string value;
-  if (attrset.find(key) != attrset.end()) {
-    value = attrset[key].to_str();
+  void get_metadata(rbox_metadata_key key, std::string* value) {
+    string str_key(1, static_cast<char>(key));
+    get_metadata(str_key, value);
   }
-  return value;
-}
 
-bool is_index_ref() { return index_ref; }
-void set_index_ref(bool ref) { this->index_ref = ref; }
-bool is_valid() { return valid; }
-void set_valid(bool valid_) { valid = valid_; }
-bool has_active_op() { return active_op; }
-string to_string(const string& padding);
-void add_metadata(const RadosMetadata& metadata) { attrset[metadata.key] = metadata.bl; }
-
-map<string, ceph::bufferlist>* get_extended_metadata() { return &this->extended_attrset; }
-void add_extended_metadata(RadosMetadata& metadata) { extended_attrset[metadata.key] = metadata.bl; }
-const string get_extended_metadata(string& key) {
-  string value;
-  if (extended_attrset.find(key) != extended_attrset.end()) {
-    value = extended_attrset[key].to_str();
+  void get_metadata(const string& key, std::string* value) {
+    if (attrset.find(key) != attrset.end()) {
+      *value = attrset[key].to_str();
+    }
   }
-  return value;
+
+  bool is_index_ref() { return index_ref; }
+  void set_index_ref(bool ref) { this->index_ref = ref; }
+  bool is_valid() { return valid; }
+  void set_valid(bool valid_) { valid = valid_; }
+  bool has_active_op() { return active_op; }
+  string to_string(const string& padding);
+  void add_metadata(const RadosMetadata& metadata) { attrset[metadata.key] = metadata.bl; }
+
+  map<string, ceph::bufferlist>* get_extended_metadata() { return &this->extended_attrset; }
+  void add_extended_metadata(RadosMetadata& metadata) { extended_attrset[metadata.key] = metadata.bl; }
+  const string get_extended_metadata(string& key) {
+    string value;
+    if (extended_attrset.find(key) != extended_attrset.end()) {
+      value = extended_attrset[key].to_str();
+    }
+    return value;
   }
 
  private:
@@ -98,10 +94,10 @@ const string get_extended_metadata(string& key) {
   map<string, ceph::bufferlist> extended_attrset;
   bool valid;
   bool index_ref;
+
  public:
   static const char X_ATTR_VERSION_VALUE[];
   static const char DATA_BUFFER_NAME[];
-
 };
 
 }  // namespace librmb

--- a/src/librmb/rados-mail.cpp
+++ b/src/librmb/rados-mail.cpp
@@ -9,7 +9,7 @@
  * Foundation.  See file COPYING.
  */
 
-#include "rados-mail-object.h"
+#include "rados-mail.h"
 
 #include <stdlib.h>
 
@@ -21,19 +21,19 @@
 using std::endl;
 using std::ostringstream;
 
-using librmb::RadosMailObject;
+using librmb::RadosMail;
 
-const char RadosMailObject::X_ATTR_VERSION_VALUE[] = "0.1";
-const char RadosMailObject::DATA_BUFFER_NAME[] = "RADOS_MAIL_BUFFER";
+const char RadosMail::X_ATTR_VERSION_VALUE[] = "0.1";
+const char RadosMail::DATA_BUFFER_NAME[] = "RADOS_MAIL_BUFFER";
 
-RadosMailObject::RadosMailObject()
+RadosMail::RadosMail()
     : object_size(-1), active_op(false), save_date_rados(-1), valid(true), index_ref(false) {}
 
-RadosMailObject::~RadosMailObject() {}
+RadosMail::~RadosMail() {}
 
-void RadosMailObject::set_guid(const uint8_t *_guid) { memcpy(this->guid, _guid, sizeof(this->guid)); }
+void RadosMail::set_guid(const uint8_t *_guid) { memcpy(this->guid, _guid, sizeof(this->guid)); }
 
-std::string RadosMailObject::to_string(const string &padding) {
+std::string RadosMail::to_string(const string &padding) {
   string uid;
   get_metadata(RBOX_METADATA_MAIL_UID, &uid);
   string recv_time_str;

--- a/src/librmb/rados-mail.h
+++ b/src/librmb/rados-mail.h
@@ -9,8 +9,8 @@
  * Foundation.  See file COPYING.
  */
 
-#ifndef SRC_LIBRMB_RADOS_MAIL_OBJECT_H_
-#define SRC_LIBRMB_RADOS_MAIL_OBJECT_H_
+#ifndef SRC_LIBRMB_RADOS_MAIL_H_
+#define SRC_LIBRMB_RADOS_MAIL_H_
 
 #include <string>
 #include <iostream>
@@ -28,10 +28,10 @@ using std::map;
 using librados::AioCompletion;
 using librados::ObjectWriteOperation;
 
-class RadosMailObject {
+class RadosMail {
  public:
-  RadosMailObject();
-  virtual ~RadosMailObject();
+  RadosMail();
+  virtual ~RadosMail();
 
   void set_oid(const char* _oid) { this->oid = _oid; }
   void set_oid(const string& _oid) { this->oid = _oid; }
@@ -102,4 +102,4 @@ class RadosMailObject {
 
 }  // namespace librmb
 
-#endif  // SRC_LIBRMB_RADOS_MAIL_OBJECT_H_
+#endif  // SRC_LIBRMB_RADOS_MAIL_H_

--- a/src/librmb/rados-metadata-storage-default.cpp
+++ b/src/librmb/rados-metadata-storage-default.cpp
@@ -21,7 +21,7 @@ RadosMetadataStorageDefault::RadosMetadataStorageDefault(librados::IoCtx *io_ctx
 RadosMetadataStorageDefault::~RadosMetadataStorageDefault() {}
 
 
-int RadosMetadataStorageDefault::load_metadata(RadosMailObject *mail) {
+int RadosMetadataStorageDefault::load_metadata(RadosMail *mail) {
   int ret = -1;
   if (mail != nullptr) {
     if (mail->get_metadata()->size() == 0) {
@@ -35,12 +35,12 @@ int RadosMetadataStorageDefault::load_metadata(RadosMailObject *mail) {
   }
   return ret;
 }
-int RadosMetadataStorageDefault::set_metadata(RadosMailObject *mail, RadosMetadata &xattr) {
+int RadosMetadataStorageDefault::set_metadata(RadosMail *mail, RadosMetadata &xattr) {
   mail->add_metadata(xattr);
   return io_ctx->setxattr(mail->get_oid(), xattr.key.c_str(), xattr.bl);
 }
 
-void RadosMetadataStorageDefault::save_metadata(librados::ObjectWriteOperation *write_op, RadosMailObject *mail) {
+void RadosMetadataStorageDefault::save_metadata(librados::ObjectWriteOperation *write_op, RadosMail *mail) {
   // update metadata
   for (std::map<string, ceph::bufferlist>::iterator it = mail->get_metadata()->begin();
        it != mail->get_metadata()->end(); ++it) {

--- a/src/librmb/rados-metadata-storage-default.h
+++ b/src/librmb/rados-metadata-storage-default.h
@@ -27,10 +27,10 @@ class RadosMetadataStorageDefault : public RadosStorageMetadataModule {
   virtual ~RadosMetadataStorageDefault();
   void set_io_ctx(librados::IoCtx *io_ctx_) override { this->io_ctx = io_ctx_; }
 
-  int load_metadata(RadosMailObject *mail) override;
-  int set_metadata(RadosMailObject *mail, RadosMetadata &xattr) override;
+  int load_metadata(RadosMail *mail) override;
+  int set_metadata(RadosMail *mail, RadosMetadata &xattr) override;
   bool update_metadata(const std::string &oid, std::list<RadosMetadata> &to_update) override;
-  void save_metadata(librados::ObjectWriteOperation *write_op, RadosMailObject *mail) override;
+  void save_metadata(librados::ObjectWriteOperation *write_op, RadosMail *mail) override;
 
   int update_keyword_metadata(const std::string &oid, RadosMetadata *metadata) override;
   int remove_keyword_metadata(const std::string &oid, std::string &key) override;

--- a/src/librmb/rados-metadata-storage-ima.cpp
+++ b/src/librmb/rados-metadata-storage-ima.cpp
@@ -26,7 +26,7 @@ RadosMetadataStorageIma::~RadosMetadataStorageIma() {
 
 }
 
-int RadosMetadataStorageIma::parse_attribute(RadosMailObject *mail, json_t *root) {
+int RadosMetadataStorageIma::parse_attribute(RadosMail *mail, json_t *root) {
   std::string key;
   void *iter = json_object_iter(root);
 
@@ -57,7 +57,7 @@ int RadosMetadataStorageIma::parse_attribute(RadosMailObject *mail, json_t *root
   return 0;
 }
 
-int RadosMetadataStorageIma::load_metadata(RadosMailObject *mail) {
+int RadosMetadataStorageIma::load_metadata(RadosMail *mail) {
   if (mail == nullptr) {
     return -1;
   }
@@ -97,7 +97,7 @@ int RadosMetadataStorageIma::load_metadata(RadosMailObject *mail) {
 }
 
 // it is required that mail->get_metadata is up to date before update.
-int RadosMetadataStorageIma::set_metadata(RadosMailObject *mail, RadosMetadata &xattr) {
+int RadosMetadataStorageIma::set_metadata(RadosMail *mail, RadosMetadata &xattr) {
   enum rbox_metadata_key k = static_cast<enum rbox_metadata_key>(*xattr.key.c_str());
   if (!cfg->is_updateable_attribute(k)) {
     mail->add_metadata(xattr);
@@ -109,7 +109,7 @@ int RadosMetadataStorageIma::set_metadata(RadosMailObject *mail, RadosMetadata &
   }
 }
 
-void RadosMetadataStorageIma::save_metadata(librados::ObjectWriteOperation *write_op, RadosMailObject *mail) {
+void RadosMetadataStorageIma::save_metadata(librados::ObjectWriteOperation *write_op, RadosMail *mail) {
   char *s = NULL;
   json_t *root = json_object();
   librados::bufferlist bl;
@@ -155,7 +155,7 @@ bool RadosMetadataStorageIma::update_metadata(const std::string &oid, std::list<
     return true;
   }
 
-  RadosMailObject obj;
+  RadosMail obj;
   obj.set_oid(oid);
   load_metadata(&obj);
 

--- a/src/librmb/rados-metadata-storage-ima.h
+++ b/src/librmb/rados-metadata-storage-ima.h
@@ -29,16 +29,16 @@ namespace librmb {
  */
 class RadosMetadataStorageIma : public RadosStorageMetadataModule {
  private:
-  int parse_attribute(RadosMailObject *mail, json_t *root);
+  int parse_attribute(RadosMail *mail, json_t *root);
 
  public:
   RadosMetadataStorageIma(librados::IoCtx *io_ctx_, RadosDovecotCephCfg *cfg_);
   virtual ~RadosMetadataStorageIma();
   void set_io_ctx(librados::IoCtx *io_ctx_) override { this->io_ctx = io_ctx_; }
-  int load_metadata(RadosMailObject *mail) override;
-  int set_metadata(RadosMailObject *mail, RadosMetadata &xattr) override;
+  int load_metadata(RadosMail *mail) override;
+  int set_metadata(RadosMail *mail, RadosMetadata &xattr) override;
   bool update_metadata(const std::string &oid, std::list<RadosMetadata> &to_update) override;
-  void save_metadata(librados::ObjectWriteOperation *write_op, RadosMailObject *mail) override;
+  void save_metadata(librados::ObjectWriteOperation *write_op, RadosMail *mail) override;
 
   int update_keyword_metadata(const std::string &oid, RadosMetadata *metadata) override;
   int remove_keyword_metadata(const std::string &oid, std::string &key) override;

--- a/src/librmb/rados-metadata-storage-module.h
+++ b/src/librmb/rados-metadata-storage-module.h
@@ -13,7 +13,8 @@
 #define SRC_LIBRMB_RADOS_METADATA_STORAGE_MODULE_H_
 
 #include <rados/librados.hpp>
-#include "rados-mail-object.h"
+
+#include "rados-mail.h"
 
 namespace librmb {
 class RadosStorageMetadataModule {
@@ -21,14 +22,14 @@ class RadosStorageMetadataModule {
   virtual ~RadosStorageMetadataModule(){};
   /* update io_ctx */
   virtual void set_io_ctx(librados::IoCtx *io_ctx){};
-  /* load the metadta into RadosMailObject */
-  virtual int load_metadata(RadosMailObject *mail) = 0;
+  /* load the metadta into RadosMail */
+  virtual int load_metadata(RadosMail *mail) = 0;
   /* set a new metadata attribute to a mail object */
-  virtual int set_metadata(RadosMailObject *mail, RadosMetadata &xattr) = 0;
+  virtual int set_metadata(RadosMail *mail, RadosMetadata &xattr) = 0;
   /* update the given metadata attributes */
   virtual bool update_metadata(const std::string &oid, std::list<RadosMetadata> &to_update) = 0;
-  /* add all metadata of RadosMailObject to write_operation */
-  virtual void save_metadata(librados::ObjectWriteOperation *write_op, RadosMailObject *mail) = 0;
+  /* add all metadata of RadosMail to write_operation */
+  virtual void save_metadata(librados::ObjectWriteOperation *write_op, RadosMail *mail) = 0;
   /* manage keywords */
   virtual int update_keyword_metadata(const std::string &oid, RadosMetadata *metadata) = 0;
   virtual int remove_keyword_metadata(const std::string &oid, std::string &key) = 0;

--- a/src/librmb/rados-storage-impl.h
+++ b/src/librmb/rados-storage-impl.h
@@ -19,7 +19,8 @@
 #include <cstdint>
 
 #include <rados/librados.hpp>
-#include "rados-mail-object.h"
+
+#include "rados-mail.h"
 #include "rados-storage.h"
 namespace librmb {
 
@@ -37,10 +38,10 @@ class RadosStorageImpl : public RadosStorage {
   int get_max_write_size() override { return max_write_size; }
   int get_max_write_size_bytes() override { return max_write_size * 1024 * 1024; }
 
-  int split_buffer_and_exec_op(RadosMailObject *current_object, librados::ObjectWriteOperation *write_op_xattr,
+  int split_buffer_and_exec_op(RadosMail *current_object, librados::ObjectWriteOperation *write_op_xattr,
                                const uint64_t &max_write) override;
 
-  int delete_mail(RadosMailObject *mail) override;
+  int delete_mail(RadosMail *mail) override;
   int delete_mail(const std::string &oid) override;
 
   int aio_operate(librados::IoCtx *io_ctx_, const std::string &oid, librados::AioCompletion *c,
@@ -52,7 +53,7 @@ class RadosStorageImpl : public RadosStorage {
   bool wait_for_write_operations_complete(
       std::map<librados::AioCompletion *, librados::ObjectWriteOperation *> *completion_op_map) override;
 
-  bool wait_for_rados_operations(const std::vector<librmb::RadosMailObject *> &object_list) override;
+  bool wait_for_rados_operations(const std::vector<librmb::RadosMail *> &object_list) override;
 
   int read_mail(const std::string &oid, librados::bufferlist *buffer) override;
   int move(std::string &src_oid, const char *src_ns, std::string &dest_oid, const char *dest_ns,
@@ -61,11 +62,11 @@ class RadosStorageImpl : public RadosStorage {
            std::list<RadosMetadata> &to_update) override;
 
   int save_mail(const std::string &oid, librados::bufferlist &buffer) override;
-  bool save_mail(RadosMailObject *mail, bool &save_async) override;
-  bool save_mail(librados::ObjectWriteOperation *write_op_xattr, RadosMailObject *mail, bool save_async) override;
-  librmb::RadosMailObject *alloc_mail_object() override;
+  bool save_mail(RadosMail *mail, bool &save_async) override;
+  bool save_mail(librados::ObjectWriteOperation *write_op_xattr, RadosMail *mail, bool save_async) override;
+  librmb::RadosMail *alloc_rados_mail() override;
 
-  void free_mail_object(librmb::RadosMailObject *mail) override;
+  void free_rados_mail(librmb::RadosMail *mail) override;
 
  private:
   int create_connection(const std::string &poolname);

--- a/src/librmb/rados-storage.h
+++ b/src/librmb/rados-storage.h
@@ -15,9 +15,9 @@
 #include <string>
 #include <map>
 
-#include "rados-mail-object.h"
 #include <rados/librados.hpp>
 #include "rados-cluster.h"
+#include "rados-mail.h"
 
 namespace librmb {
 
@@ -42,11 +42,11 @@ class RadosStorage {
 
   /* In case the current object size exceeds the max_write (bytes), object should be split into
    * max smaller operations and executed separately. */
-  virtual int split_buffer_and_exec_op(RadosMailObject *current_object, librados::ObjectWriteOperation *write_op_xattr,
+  virtual int split_buffer_and_exec_op(RadosMail *current_object, librados::ObjectWriteOperation *write_op_xattr,
                                        const uint64_t &max_write) = 0;
 
   /* deletes a mail object from rados*/
-  virtual int delete_mail(RadosMailObject *mail) = 0;
+  virtual int delete_mail(RadosMail *mail) = 0;
   virtual int delete_mail(const std::string &oid) = 0;
   /* asynchron execution of a write operation */
   virtual int aio_operate(librados::IoCtx *io_ctx_, const std::string &oid, librados::AioCompletion *c,
@@ -62,8 +62,8 @@ class RadosStorage {
 
   /* wait for all write operations to complete */
   virtual bool wait_for_write_operations_complete(
-      std::map<librados::AioCompletion*, librados::ObjectWriteOperation*>* completion_op_map) = 0;
-  virtual bool wait_for_rados_operations(const std::vector<librmb::RadosMailObject *> &object_list) = 0;
+      std::map<librados::AioCompletion *, librados::ObjectWriteOperation *> *completion_op_map) = 0;
+  virtual bool wait_for_rados_operations(const std::vector<librmb::RadosMail *> &object_list) = 0;
 
   /* save the mail object */
   virtual int save_mail(const std::string &oid, librados::bufferlist &buffer) = 0;
@@ -76,12 +76,12 @@ class RadosStorage {
   virtual int copy(std::string &src_oid, const char *src_ns, std::string &dest_oid, const char *dest_ns,
                    std::list<RadosMetadata> &to_update) = 0;
   /* save the mail */
-  virtual bool save_mail(RadosMailObject *mail, bool &save_async) = 0;
-  virtual bool save_mail(librados::ObjectWriteOperation *write_op_xattr, RadosMailObject *mail, bool save_async) = 0;
-  /* create a new RadosMailObject */
-  virtual librmb::RadosMailObject *alloc_mail_object() = 0;
+  virtual bool save_mail(RadosMail *mail, bool &save_async) = 0;
+  virtual bool save_mail(librados::ObjectWriteOperation *write_op_xattr, RadosMail *mail, bool save_async) = 0;
+  /* create a new RadosMail */
+  virtual librmb::RadosMail *alloc_rados_mail() = 0;
   /* free the Rados Mail Object */
-  virtual void free_mail_object(librmb::RadosMailObject *mail) = 0;
+  virtual void free_rados_mail(librmb::RadosMail *mail) = 0;
 };
 
 }  // namespace librmb

--- a/src/librmb/rados-util.cpp
+++ b/src/librmb/rados-util.cpp
@@ -234,7 +234,7 @@ int RadosUtils::copy_to_alt(std::string &src_oid, std::string &dest_oid, RadosSt
     return 0;
   }
 
-  RadosMailObject mail;
+  RadosMail mail;
   mail.set_oid(src_oid);
 
   if (inverse) {
@@ -272,7 +272,7 @@ int RadosUtils::copy_to_alt(std::string &src_oid, std::string &dest_oid, RadosSt
     return 0;
   }
 
-  std::vector<librmb::RadosMailObject *> objects;
+  std::vector<librmb::RadosMail *> objects;
   objects.push_back(&mail);
   if (inverse) {
     success = primary->wait_for_rados_operations(objects);

--- a/src/librmb/tools/rmb/ls_cmd_parser.h
+++ b/src/librmb/tools/rmb/ls_cmd_parser.h
@@ -17,7 +17,8 @@
 #include <iostream>
 #include <ctime>
 #include <map>
-#include "rados-mail-object.h"
+
+#include "../../rados-mail.h"
 #include "rados-util.h"
 
 #ifndef PATH_MAX

--- a/src/librmb/tools/rmb/mailbox_tools.cpp
+++ b/src/librmb/tools/rmb/mailbox_tools.cpp
@@ -97,7 +97,9 @@ int MailboxTools::build_filename(librmb::RadosMailObject* mail_obj, std::string*
   }
 
   std::stringstream ss;
-  ss << mail_obj->get_metadata(librmb::RBOX_METADATA_MAIL_UID) << ".";
+  std::string m_mail_uid;
+  mail_obj->get_metadata(librmb::RBOX_METADATA_MAIL_UID, &m_mail_uid);
+  ss << m_mail_uid << ".";
   ss << mail_obj->get_oid();
   *filename = ss.str();
   return filename->empty() ? -1 : 0;

--- a/src/librmb/tools/rmb/mailbox_tools.cpp
+++ b/src/librmb/tools/rmb/mailbox_tools.cpp
@@ -46,7 +46,7 @@ int MailboxTools::init_mailbox_dir() {
   return 0;
 }
 
-int MailboxTools::delete_mail(librmb::RadosMailObject* mail_obj) {
+int MailboxTools::delete_mail(librmb::RadosMail* mail_obj) {
   if (mail_obj == nullptr) {
     return -1;
   }
@@ -71,7 +71,7 @@ int MailboxTools::delete_mailbox_dir() {
   return 0;
 }
 
-int MailboxTools::save_mail(librmb::RadosMailObject* mail_obj) {
+int MailboxTools::save_mail(librmb::RadosMail* mail_obj) {
   if (mail_obj == nullptr) {
     return -1;
   }
@@ -91,7 +91,7 @@ int MailboxTools::save_mail(librmb::RadosMailObject* mail_obj) {
   return 0;
 }
 
-int MailboxTools::build_filename(librmb::RadosMailObject* mail_obj, std::string* filename) {
+int MailboxTools::build_filename(librmb::RadosMail* mail_obj, std::string* filename) {
   if (mail_obj == nullptr || !filename->empty()) {
     return -1;
   }

--- a/src/librmb/tools/rmb/mailbox_tools.h
+++ b/src/librmb/tools/rmb/mailbox_tools.h
@@ -13,7 +13,8 @@
 #define SRC_LIBRMB_TOOLS_RMB_MAILBOX_TOOLS_H_
 
 #include <string>
-#include "rados-mail-object.h"
+
+#include "../../rados-mail.h"
 #include "rados-mail-box.h"
 
 namespace librmb {
@@ -23,11 +24,11 @@ class MailboxTools {
   ~MailboxTools() {}
 
   int init_mailbox_dir();
-  int save_mail(librmb::RadosMailObject* mail_obj);
+  int save_mail(librmb::RadosMail* mail_obj);
   int delete_mailbox_dir();
-  int delete_mail(librmb::RadosMailObject* mail_obj);
+  int delete_mail(librmb::RadosMail* mail_obj);
 
-  int build_filename(librmb::RadosMailObject* mail_obj, std::string* filename);
+  int build_filename(librmb::RadosMail* mail_obj, std::string* filename);
 
   std::string& get_mailbox_path() { return this->mailbox_path; }
 

--- a/src/librmb/tools/rmb/rados-mail-box.h
+++ b/src/librmb/tools/rmb/rados-mail-box.h
@@ -16,7 +16,8 @@
 #include <sstream>
 #include <vector>
 #include <map>
-#include "rados-mail-object.h"
+
+#include "../../rados-mail.h"
 #include "ls_cmd_parser.h"
 namespace librmb {
 
@@ -30,7 +31,7 @@ class RadosMailBox {
   }
   virtual ~RadosMailBox() {}
 
-  void add_mail(RadosMailObject *mail) {
+  void add_mail(RadosMail *mail) {
     total_mails++;
     if (!mail->is_valid()) {
       mails.push_back(mail);
@@ -72,17 +73,17 @@ class RadosMailBox {
        << "         mailbox_size=" << mailbox_size << " bytes " << std::endl;
 
     std::string padding("         ");
-    for (std::vector<RadosMailObject *>::iterator it = mails.begin(); it != mails.end(); ++it) {
+    for (std::vector<RadosMail *>::iterator it = mails.begin(); it != mails.end(); ++it) {
       ss << (*it)->to_string(padding);
     }
     return ss.str();
   }
   inline void add_to_mailbox_size(const uint64_t &_mailbox_size) { this->mailbox_size += _mailbox_size; }
-  void set_mails(const std::vector<RadosMailObject *> &_mails) { this->mails = _mails; }
+  void set_mails(const std::vector<RadosMail *> &_mails) { this->mails = _mails; }
 
   CmdLineParser *get_xattr_filter() { return this->parser; }
   void set_xattr_filter(CmdLineParser *_parser) { this->parser = _parser; }
-  std::vector<RadosMailObject *> &get_mails() { return this->mails; }
+  std::vector<RadosMail *> &get_mails() { return this->mails; }
 
   std::string &get_mailbox_guid() { return this->mailbox_guid; }
   void set_mailbox_guid(const std::string &_mailbox_guid) { this->mailbox_guid = _mailbox_guid; }
@@ -95,7 +96,7 @@ class RadosMailBox {
   std::string mailbox_guid;
   int mail_count;
   uint64_t mailbox_size;
-  std::vector<RadosMailObject *> mails;
+  std::vector<RadosMail *> mails;
   uint64_t total_mails;
   std::string mbox_orig_name;
 };

--- a/src/librmb/tools/rmb/rados-mail-box.h
+++ b/src/librmb/tools/rmb/rados-mail-box.h
@@ -22,10 +22,8 @@ namespace librmb {
 
 class RadosMailBox {
  public:
-
-  RadosMailBox(const std::string& _mailbox_guid, int _mail_count, const std::string &_mbox_orig_name) : mailbox_guid(_mailbox_guid),
-													mail_count(_mail_count),
-													mbox_orig_name(_mbox_orig_name) {
+  RadosMailBox(const std::string &_mailbox_guid, int _mail_count, const std::string &_mbox_orig_name)
+      : mailbox_guid(_mailbox_guid), mail_count(_mail_count), mbox_orig_name(_mbox_orig_name) {
     this->mailbox_size = 0;
     this->total_mails = 0;
     this->parser = nullptr;
@@ -50,7 +48,9 @@ class RadosMailBox {
          it != parser->get_predicates().end(); ++it) {
       if (mail->get_metadata()->find(it->first) != mail->get_metadata()->end()) {
         std::string key = it->first;
-        if (it->second->eval(mail->get_metadata(key))) {
+        std::string value;
+        mail->get_metadata(key, &value);
+        if (it->second->eval(value)) {
           mails.push_back(mail);
         }
         return;

--- a/src/librmb/tools/rmb/rmb-commands.h
+++ b/src/librmb/tools/rmb/rmb-commands.h
@@ -11,10 +11,11 @@
 
 #ifndef SRC_LIBRMB_TOOLS_RMB_RMB_COMMANDS_H_
 #define SRC_LIBRMB_TOOLS_RMB_RMB_COMMANDS_H_
+#include <stdlib.h>
+
 #include <iostream>
 #include <map>
 #include <string>
-#include <stdlib.h>
 #include <vector>
 #include <sstream>
 #include <iterator>

--- a/src/librmb/tools/rmb/rmb-commands.h
+++ b/src/librmb/tools/rmb/rmb-commands.h
@@ -45,24 +45,24 @@ class RmbCommands {
   void print_debug(const std::string &msg);
   static int lspools();
   int delete_mail(bool confirmed);
-  int delete_namespace(librmb::RadosStorageMetadataModule *ms, std::vector<librmb::RadosMailObject *> &mail_objects,
+  int delete_namespace(librmb::RadosStorageMetadataModule *ms, std::vector<librmb::RadosMail *> &mail_objects,
                        librmb::RadosCephConfig *cfg, bool confirmed);
 
   int rename_user(librmb::RadosCephConfig *cfg, bool confirmed, const std::string &uid);
 
   int configuration(bool confirmed, librmb::RadosCephConfig &ceph_cfg);
 
-  int load_objects(librmb::RadosStorageMetadataModule *ms, std::vector<librmb::RadosMailObject *> &mail_objects,
+  int load_objects(librmb::RadosStorageMetadataModule *ms, std::vector<librmb::RadosMail *> &mail_objects,
                    std::string &sort_string, bool load_metadata = true);
   int update_attributes(librmb::RadosStorageMetadataModule *ms, std::map<std::string, std::string> *metadata);
   int print_mail(std::map<std::string, librmb::RadosMailBox *> *mailbox, std::string &output_dir, bool download);
-  int query_mail_storage(std::vector<librmb::RadosMailObject *> *mail_objects, librmb::CmdLineParser *parser,
+  int query_mail_storage(std::vector<librmb::RadosMail *> *mail_objects, librmb::CmdLineParser *parser,
                          bool download, bool silent);
   librmb::RadosStorageMetadataModule *init_metadata_storage_module(librmb::RadosCephConfig &ceph_cfg, std::string *uid);
-  static bool sort_uid(librmb::RadosMailObject *i, librmb::RadosMailObject *j);
-  static bool sort_recv_date(librmb::RadosMailObject *i, librmb::RadosMailObject *j);
-  static bool sort_phy_size(librmb::RadosMailObject *i, librmb::RadosMailObject *j);
-  static bool sort_save_date(librmb::RadosMailObject *i, librmb::RadosMailObject *j);
+  static bool sort_uid(librmb::RadosMail *i, librmb::RadosMail *j);
+  static bool sort_recv_date(librmb::RadosMail *i, librmb::RadosMail *j);
+  static bool sort_phy_size(librmb::RadosMail *i, librmb::RadosMail *j);
+  static bool sort_save_date(librmb::RadosMail *i, librmb::RadosMail *j);
 
   void set_output_path(librmb::CmdLineParser *parser);
 

--- a/src/librmb/tools/rmb/rmb.cpp
+++ b/src/librmb/tools/rmb/rmb.cpp
@@ -23,11 +23,11 @@
 
 #include "../../rados-cluster.h"
 #include "../../rados-cluster-impl.h"
+#include "../../rados-mail.h"
 #include "../../rados-storage.h"
 #include "../../rados-storage-impl.h"
 #include "../../rados-metadata-storage-ima.h"
 #include "../../rados-metadata-storage-module.h"
-#include "rados-mail-object.h"
 #include "ls_cmd_parser.h"
 #include "mailbox_tools.h"
 #include "rados-util.h"
@@ -193,7 +193,7 @@ __attribute__((noreturn)) static void usage_exit() {
   exit(1);
 }
 
-static void release_exit(std::vector<librmb::RadosMailObject *> *mail_objects, librmb::RadosCluster *cluster,
+static void release_exit(std::vector<librmb::RadosMail *> *mail_objects, librmb::RadosCluster *cluster,
                          bool show_usage) {
   if (mail_objects != nullptr) {
     for (auto mo : *mail_objects) {
@@ -272,7 +272,7 @@ static void parse_cmd_line_args(std::map<std::string, std::string> *opts, bool &
 }
 
 int main(int argc, const char **argv) {
-  std::vector<librmb::RadosMailObject *> mail_objects;
+  std::vector<librmb::RadosMail *> mail_objects;
   std::vector<const char *> args;
 
   std::map<std::string, std::string> opts;

--- a/src/storage-rbox/doveadm-rbox-plugin.cpp
+++ b/src/storage-rbox/doveadm-rbox-plugin.cpp
@@ -471,9 +471,9 @@ static int restore_index_entry(struct mail_user *user, const char *mailbox_name,
 
   memcpy(rec.guid, mail_guid, sizeof(mail_guid));
   memcpy(rec.oid, mail_oid, sizeof(mail_oid));
-  struct rbox_mailbox *mbox = (struct rbox_mailbox *)box;
+  struct rbox_mailbox *rbox = (struct rbox_mailbox *)box;
 
-  mail_index_update_ext(save_ctx->transaction->itrans, seq, mbox->ext_id, &rec, NULL);
+  mail_index_update_ext(save_ctx->transaction->itrans, seq, rbox->ext_id, &rec, NULL);
 
   save_ctx->transaction->save_count++;
   r_ctx->finished = TRUE;
@@ -627,7 +627,7 @@ static int iterate_mailbox(const struct mail_namespace *ns, const struct mailbox
 
   search_ctx = mailbox_search_init(mailbox_transaction, search_args, NULL, static_cast<mail_fetch_field>(0), NULL);
   mail_search_args_unref(&search_args);
-  struct rbox_mailbox *mbox = (struct rbox_mailbox *)box;
+  struct rbox_mailbox *rbox = (struct rbox_mailbox *)box;
   std::cout << "box: " << info->vname << std::endl;
   int mail_count = 0;
   int mail_count_missing = 0;
@@ -635,7 +635,7 @@ static int iterate_mailbox(const struct mail_namespace *ns, const struct mailbox
     ++mail_count;
     const struct obox_mail_index_record *obox_rec;
     const void *rec_data;
-    mail_index_lookup_ext(mail->transaction->view, mail->seq, mbox->ext_id, &rec_data, NULL);
+    mail_index_lookup_ext(mail->transaction->view, mail->seq, rbox->ext_id, &rec_data, NULL);
     obox_rec = static_cast<const struct obox_mail_index_record *>(rec_data);
 
     if (obox_rec == nullptr) {

--- a/src/storage-rbox/doveadm-rbox-plugin.cpp
+++ b/src/storage-rbox/doveadm-rbox-plugin.cpp
@@ -49,8 +49,7 @@ extern "C" {
 #include "rbox-save.h"
 #include "rbox-storage.hpp"
 
-int check_namespace_mailboxes(const struct mail_namespace *ns,
-                              const std::vector<librmb::RadosMailObject *> &mail_objects);
+int check_namespace_mailboxes(const struct mail_namespace *ns, const std::vector<librmb::RadosMail *> &mail_objects);
 
 class RboxDoveadmPlugin {
  public:
@@ -148,7 +147,7 @@ static int cmd_rmb_config(const std::map<std::string, std::string> &opts) {
   return 0;
 }
 static int cmd_rmb_search_run(std::map<std::string, std::string> &opts, struct mail_user *user, bool download,
-                              librmb::CmdLineParser &parser, std::vector<librmb::RadosMailObject *> &mail_objects,
+                              librmb::CmdLineParser &parser, std::vector<librmb::RadosMail *> &mail_objects,
                               bool silent, bool load_metadata = true) {
   RboxDoveadmPlugin plugin;
   int open = open_connection_load_config(&plugin);
@@ -210,12 +209,12 @@ static int cmd_rmb_ls_run(struct doveadm_mail_cmd_context *ctx, struct mail_user
   librmb::CmdLineParser parser(opts["ls"]);
 
   if (opts["ls"].compare("all") == 0 || opts["ls"].compare("-") == 0 || parser.parse_ls_string()) {
-    std::vector<librmb::RadosMailObject *> mail_objects;
+    std::vector<librmb::RadosMail *> mail_objects;
 
     ctx->exit_code = cmd_rmb_search_run(opts, user, false, parser, mail_objects, false);
 
     auto it_mail = std::find_if(mail_objects.begin(), mail_objects.end(),
-                                [](librmb::RadosMailObject *n) -> bool { return n->is_index_ref() == false; });
+                                [](librmb::RadosMail *n) -> bool { return n->is_index_ref() == false; });
 
     if (it_mail != mail_objects.end()) {
       std::cout << "There are unreferenced objects " << std::endl;
@@ -236,7 +235,7 @@ static int cmd_rmb_ls_mb_run(struct doveadm_mail_cmd_context *ctx, struct mail_u
   opts["sort"] = "uid";
   librmb::CmdLineParser parser(opts["ls"]);
   if (opts["ls"].compare("all") == 0 || opts["ls"].compare("-") == 0 || parser.parse_ls_string()) {
-    std::vector<librmb::RadosMailObject *> mail_objects;
+    std::vector<librmb::RadosMail *> mail_objects;
     ctx->exit_code = cmd_rmb_search_run(opts, user, false, parser, mail_objects, false);
   } else {
     i_error("invalid ls search query");
@@ -264,7 +263,7 @@ static int cmd_rmb_get_run(struct doveadm_mail_cmd_context *ctx, struct mail_use
 
   librmb::CmdLineParser parser(opts["get"]);
   if (opts["get"].compare("all") == 0 || opts["ls"].compare("-") == 0 || parser.parse_ls_string()) {
-    std::vector<librmb::RadosMailObject *> mail_objects;
+    std::vector<librmb::RadosMail *> mail_objects;
     ctx->exit_code = cmd_rmb_search_run(opts, user, true, parser, mail_objects, false);
     for (auto mo : mail_objects) {
       delete mo;
@@ -600,7 +599,7 @@ static int cmd_rmb_revert_log_run(struct doveadm_mail_cmd_context *ctx, struct m
 }
 
 static int iterate_mailbox(const struct mail_namespace *ns, const struct mailbox_info *info,
-                           const std::vector<librmb::RadosMailObject *> &mail_objects) {
+                           const std::vector<librmb::RadosMail *> &mail_objects) {
   int ret = 0;
   struct mailbox_transaction_context *mailbox_transaction;
   struct mail_search_context *search_ctx;
@@ -646,7 +645,7 @@ static int iterate_mailbox(const struct mail_namespace *ns, const struct mailbox
     std::string oid = guid_128_to_string(obox_rec->oid);
 
     auto it_mail = std::find_if(mail_objects.begin(), mail_objects.end(),
-                                [oid](librmb::RadosMailObject *m) { return m->get_oid().compare(oid) == 0; });
+                                [oid](librmb::RadosMail *m) { return m->get_oid().compare(oid) == 0; });
 
     if (it_mail == mail_objects.end()) {
       /*  std::cout << "   missing mail object: uid=" << mail->uid << " guid=" << guid << " oid : " << oid
@@ -654,7 +653,7 @@ static int iterate_mailbox(const struct mail_namespace *ns, const struct mailbox
       ++mail_count_missing;
     } else {
       (*it_mail)->set_index_ref(true);
-      // mail_objects.erase(it_mail);  // calls destructor of RadosMailObject*
+      // mail_objects.erase(it_mail);  // calls destructor of RadosMail*
     }
   }
   if (mailbox_search_deinit(&search_ctx) < 0) {
@@ -673,8 +672,7 @@ static int iterate_mailbox(const struct mail_namespace *ns, const struct mailbox
   return ret;
 }
 
-int check_namespace_mailboxes(const struct mail_namespace *ns,
-                              const std::vector<librmb::RadosMailObject *> &mail_objects) {
+int check_namespace_mailboxes(const struct mail_namespace *ns, const std::vector<librmb::RadosMail *> &mail_objects) {
   struct mailbox_list_iterate_context *iter;
   const struct mailbox_info *info;
   int ret = 0;
@@ -703,7 +701,7 @@ static int cmd_rmb_check_indices_run(struct doveadm_mail_cmd_context *ctx, struc
   opts["sort"] = "uid";
   librmb::CmdLineParser parser(opts["ls"]);
   parser.parse_ls_string();
-  std::vector<librmb::RadosMailObject *> mail_objects;
+  std::vector<librmb::RadosMail *> mail_objects;
   ctx->exit_code = cmd_rmb_search_run(opts, user, false, parser, mail_objects, true, false);
   if (ctx->exit_code < 0) {
     return 0;
@@ -715,7 +713,7 @@ static int cmd_rmb_check_indices_run(struct doveadm_mail_cmd_context *ctx, struc
   }
 
   auto it_mail = std::find_if(mail_objects.begin(), mail_objects.end(),
-                              [](librmb::RadosMailObject *m) { return m->is_index_ref() == false; });
+                              [](librmb::RadosMail *m) { return m->is_index_ref() == false; });
 
   if (it_mail != mail_objects.end()) {
     std::cout << std::endl << "There are mail objects without a index reference: " << std::endl;

--- a/src/storage-rbox/istream-bufferlist.cpp
+++ b/src/storage-rbox/istream-bufferlist.cpp
@@ -39,7 +39,6 @@ struct istream *i_stream_create_from_bufferlist(librados::bufferlist *data, cons
   stream->buffer = reinterpret_cast<const unsigned char *>(data->c_str());
   stream->pos = size;
   stream->max_buffer_size = (size_t)-1;
-  ;
 
   stream->read = i_stream_data_read;
   stream->seek = i_stream_data_seek;  // use default
@@ -58,4 +57,3 @@ struct istream *i_stream_create_from_bufferlist(librados::bufferlist *data, cons
   i_stream_set_name(&stream->istream, "(buffer)");
   return &stream->istream;
 }
-

--- a/src/storage-rbox/ostream-bufferlist.cpp
+++ b/src/storage-rbox/ostream-bufferlist.cpp
@@ -9,6 +9,7 @@
  * License version 2.1, as published by the Free Software
  * Foundation.  See file COPYING.
  */
+#include <string>
 
 extern "C" {
 #include "lib.h"

--- a/src/storage-rbox/rbox-copy.cpp
+++ b/src/storage-rbox/rbox-copy.cpp
@@ -107,6 +107,7 @@ static int rbox_mail_save_copy_default_metadata(struct mail_save_context *ctx, s
 
 static void set_mailbox_metadata(struct mail_save_context *ctx, std::list<librmb::RadosMetadata> *metadata_update) {
   {
+    FUNC_START();
     struct mailbox *dest_mbox = ctx->transaction->box;
     struct rbox_save_context *r_ctx = (struct rbox_save_context *)ctx;
     struct rbox_storage *r_storage = (struct rbox_storage *)&r_ctx->mbox->storage->storage;
@@ -126,20 +127,13 @@ static void set_mailbox_metadata(struct mail_save_context *ctx, std::list<librmb
       }
     }
   }
+  FUNC_END();
 }
 
-static int rbox_mail_storage_try_copy(struct mail_save_context **_ctx, struct mail *mail, bool from_alt_storage) {
-  FUNC_START();
-  struct mail_save_context *ctx = *_ctx;
-  struct rbox_save_context *r_ctx = (struct rbox_save_context *)ctx;
-  struct rbox_storage *r_storage = (struct rbox_storage *)&r_ctx->mbox->storage->storage;
-  struct rbox_mail *rmail = (struct rbox_mail *)mail;
-  struct rbox_mailbox *rmailbox = (struct rbox_mailbox *)mail->box;
-
-  struct mailbox *dest_mbox = ctx->transaction->box;
-
+static int get_src_dest_namespace(const struct rbox_storage *r_storage, const struct mail *mail,
+                                  const struct mailbox *dest_mbox,
+                                  /*out*/ std::string *ns_src, /*out*/ std::string *ns_dest) {
   std::string ns_src_mail1;
-
   if (mail->box->list->ns->owner != nullptr) {
     ns_src_mail1 = mail->box->list->ns->owner->username;
     ns_src_mail1 += r_storage->config->get_user_suffix();
@@ -155,22 +149,148 @@ static int rbox_mail_storage_try_copy(struct mail_save_context **_ctx, struct ma
     ns_dest_mail1 = r_storage->config->get_public_namespace();
   }
 
-  std::string ns_src;
-  if (!r_storage->ns_mgr->lookup_key(ns_src_mail1, &ns_src)) {
+  if (!r_storage->ns_mgr->lookup_key(ns_src_mail1, ns_src)) {
     i_error("not initialized : ns_src");
     return -1;
   }
   //  ns_src = "raw mail user";
-  std::string ns_dest;
-  if (!r_storage->ns_mgr->lookup_key(ns_dest_mail1, &ns_dest)) {
+  if (!r_storage->ns_mgr->lookup_key(ns_dest_mail1, ns_dest)) {
     i_error("not_initialized : ns_dest");
     return -1;
   }
+  return 0;
+}
+
+static int copy_mail(struct mail_save_context *ctx, librmb::RadosStorage *rados_storage, struct rbox_mail *rmail,
+                     const std::string *ns_src, const std::string *ns_dest) {
+  struct rbox_save_context *r_ctx = (struct rbox_save_context *)ctx;
+  struct rbox_storage *r_storage = (struct rbox_storage *)&r_ctx->mbox->storage->storage;
+
+  std::list<librmb::RadosMetadata> metadata_update;
+  std::string src_oid = rmail->mail_object->get_oid();
+
+  setup_mail_object(ctx);
+
+  std::string dest_oid = r_ctx->current_object->get_oid();
+
+  set_mailbox_metadata(ctx, &metadata_update);
+
+  int ret_val = rados_storage->copy(src_oid, ns_src->c_str(), dest_oid, ns_dest->c_str(), metadata_update);
+  if (ret_val < 0) {
+    if (ret_val == -ENOENT) {
+      i_warning(
+          "copy mail failed: from namespace: %s to namespace %s: src_oid: %s, des_oid: %s, error_code: %d, "
+          "storage_pool: %s , most likely concurency issue",
+          ns_src->c_str(), ns_dest->c_str(), src_oid.c_str(), dest_oid.c_str(), ret_val,
+          rados_storage->get_pool_name().c_str());
+      rbox_mail_set_expunged(rmail);
+      return 0;
+    }
+    i_error(
+        "copy mail failed: from namespace: %s to namespace %s: src_oid: %s, des_oid: %s, error_code: %d, "
+        "storage_pool: %s",
+        ns_src->c_str(), ns_dest->c_str(), src_oid.c_str(), dest_oid.c_str(), ret_val,
+        rados_storage->get_pool_name().c_str());
+    FUNC_END_RET("ret == -1, rados_storage->copy failed");
+    rados_storage->free_mail_object(r_ctx->current_object);
+    r_ctx->current_object = nullptr;
+    return -1;
+  }
+
+  rbox_add_to_index(ctx);
+  if (r_storage->save_log->is_open()) {
+    r_storage->save_log->append(librmb::RadosSaveLogEntry(dest_oid, *ns_dest, rados_storage->get_pool_name(),
+                                                          librmb::RadosSaveLogEntry::op_cpy()));
+  }
+#ifdef DEBUG
+  i_debug("copy successfully finished: from src %s to oid = %s", src_oid.c_str(), dest_oid.c_str());
+#endif
+  return 0;
+}
+
+static int move_mail(struct mail_save_context *ctx, librmb::RadosStorage *rados_storage, struct mail *mail,
+                     const std::string *ns_src, const std::string *ns_dest) {
+  struct rbox_save_context *r_ctx = (struct rbox_save_context *)ctx;
+  struct rbox_storage *r_storage = (struct rbox_storage *)&r_ctx->mbox->storage->storage;
+  struct rbox_mailbox *rmailbox = (struct rbox_mailbox *)mail->box;
+  struct rbox_mail *rmail = (struct rbox_mail *)mail;
+  struct mailbox *dest_mbox = ctx->transaction->box;
+
+  std::list<librmb::RadosMetadata> metadata_update;
+  std::string src_oid = rmail->mail_object->get_oid();
+  std::string dest_oid = src_oid;
+
+  set_mailbox_metadata(ctx, &metadata_update);
+
+  bool delete_source = true;
+  int ret_val =
+      rados_storage->move(src_oid, ns_src->c_str(), dest_oid, ns_dest->c_str(), metadata_update, delete_source);
+  if (ret_val < 0) {
+    if (ret_val == -ENOENT) {
+      i_warning(
+          "move mail failed: from namespace: %s to namespace %s: src_oid: %s, des_oid: %s, error_code : %d, "
+          "pool_name: %s. most likely due to concurency issues",
+          ns_src->c_str(), ns_dest->c_str(), src_oid.c_str(), dest_oid.c_str(), ret_val,
+          rados_storage->get_pool_name().c_str());
+      rbox_mail_set_expunged(rmail);
+      return 0;
+    }
+    i_error(
+        "move mail failed: from namespace: %s to namespace %s: src_oid: %s, des_oid: %s, error_code : %d, "
+        "pool_name: %s",
+        ns_src->c_str(), ns_dest->c_str(), src_oid.c_str(), dest_oid.c_str(), ret_val,
+        rados_storage->get_pool_name().c_str());
+    FUNC_END_RET("ret == -1, rados_storage->move failed");
+    return -1;
+  }
+
+  // set src as expunged
+  struct expunged_item *item = p_new(default_pool, struct expunged_item, 1);
+  i_zero(item);
+  guid_128_from_string(src_oid.c_str(), item->oid);
+  array_append(&rmailbox->moved_items, &item, 1);
+
+  rbox_move_index(ctx, mail);
+  if (r_storage->save_log->is_open()) {
+    std::list<librmb::RadosMetadata *> metadata;
+    librmb::RadosMetadata mailbox_guid(librmb::RBOX_METADATA_MAILBOX_GUID, guid_128_to_string(rmailbox->mailbox_guid));
+    librmb::RadosMetadata mb_name(librmb::RBOX_METADATA_ORIG_MAILBOX, rmailbox->box.vname);
+
+    librmb::RadosMetadata uid(librmb::RBOX_METADATA_MAIL_UID, mail->uid);
+    librmb::RadosMetadata guid(librmb::RBOX_METADATA_GUID, guid_128_to_string(r_ctx->mail_guid));
+    metadata.push_back(&mailbox_guid);
+    metadata.push_back(&mb_name);
+    metadata.push_back(&uid);
+    metadata.push_back(&guid);
+
+    r_storage->save_log->append(librmb::RadosSaveLogEntry(
+        dest_oid, *ns_dest, rados_storage->get_pool_name(),
+        librmb::RadosSaveLogEntry::op_mv(*ns_src, src_oid, dest_mbox->list->ns->owner->username, metadata)));
+  }
+#ifdef DEBUG
+  i_debug("move successfully finished from %s (ns=%s) to %s (ns=%s)", src_oid.c_str(), ns_src.c_str(), src_oid.c_str(),
+          ns_dest.c_str());
+#endif
+  return 0;
+}
+
+static int rbox_mail_storage_try_copy(struct mail_save_context **_ctx, struct mail *mail, bool from_alt_storage) {
+  FUNC_START();
+  struct mail_save_context *ctx = *_ctx;
+  struct rbox_save_context *r_ctx = (struct rbox_save_context *)ctx;
+  struct rbox_storage *r_storage = (struct rbox_storage *)&r_ctx->mbox->storage->storage;
+  struct rbox_mail *rmail = (struct rbox_mail *)mail;
+
+  std::string ns_src;
+  std::string ns_dest;
+  struct mailbox *dest_mbox = ctx->transaction->box;
+  if (get_src_dest_namespace(r_storage, mail, dest_mbox, &ns_src, &ns_dest) < 0) {
+    return -1;
+  }
+
 #ifdef DEBUG
   i_debug("namespaces: src=%s, dst=%s", ns_src.c_str(), ns_dest.c_str());
 #endif
-
-  int ret_val = 0;
 
   if (r_ctx->copying == TRUE) {
     if (rbox_get_index_record(mail) < 0) {
@@ -184,102 +304,16 @@ static int rbox_mail_storage_try_copy(struct mail_save_context **_ctx, struct ma
       return -1;
     }
 
-    std::list<librmb::RadosMetadata> metadata_update;  // metadata which needs to be unique goes here
-    std::string src_oid = rmail->mail_object->get_oid();
-
     librmb::RadosStorage *rados_storage = !from_alt_storage ? r_storage->s : r_storage->alt;
-
     if (ctx->moving != TRUE) {
-      setup_mail_object(ctx);
-      std::string dest_oid = r_ctx->current_object->get_oid();
-
-      set_mailbox_metadata(ctx, &metadata_update);
-
-      ret_val = rados_storage->copy(src_oid, ns_src.c_str(), dest_oid, ns_dest.c_str(), metadata_update);
-      if (ret_val < 0) {
-        if (ret_val == -ENOENT) {
-          i_warning(
-              "copy mail failed: from namespace: %s to namespace %s: src_oid: %s, des_oid: %s, error_code: %d, "
-              "storage_pool: %s , most likely concurency issue",
-              ns_src.c_str(), ns_dest.c_str(), src_oid.c_str(), dest_oid.c_str(), ret_val,
-              rados_storage->get_pool_name().c_str());
-          rbox_mail_set_expunged(rmail);
-          return 0;
-        }
-        i_error(
-            "copy mail failed: from namespace: %s to namespace %s: src_oid: %s, des_oid: %s, error_code: %d, "
-            "storage_pool: %s",
-            ns_src.c_str(), ns_dest.c_str(), src_oid.c_str(), dest_oid.c_str(), ret_val,
-            rados_storage->get_pool_name().c_str());
-        FUNC_END_RET("ret == -1, rados_storage->copy failed");
-        rados_storage->free_mail_object(r_ctx->current_object);
-        r_ctx->current_object = nullptr;
+      if (copy_mail(ctx, rados_storage, rmail, &ns_src, &ns_dest) < 0) {
         return -1;
       }
-
-      rbox_add_to_index(ctx);
-      if (r_storage->save_log->is_open()) {
-        r_storage->save_log->append(librmb::RadosSaveLogEntry(dest_oid, ns_dest, rados_storage->get_pool_name(),
-                                                              librmb::RadosSaveLogEntry::op_cpy()));
-      }
-#ifdef DEBUG
-      i_debug("copy successfully finished: from src %s to oid = %s", src_oid.c_str(), dest_oid.c_str());
-#endif
     }
     if (ctx->moving) {
-      std::string dest_oid = src_oid;
-
-      set_mailbox_metadata(ctx, &metadata_update);
-
-      bool delete_source = true;
-      ret_val = rados_storage->move(src_oid, ns_src.c_str(), dest_oid, ns_dest.c_str(), metadata_update, delete_source);
-      if (ret_val < 0) {
-        if (ret_val == -ENOENT) {
-          i_warning(
-              "move mail failed: from namespace: %s to namespace %s: src_oid: %s, des_oid: %s, error_code : %d, "
-              "pool_name: %s. most likely due to concurency issues",
-              ns_src.c_str(), ns_dest.c_str(), src_oid.c_str(), dest_oid.c_str(), ret_val,
-              rados_storage->get_pool_name().c_str());
-          rbox_mail_set_expunged(rmail);
-          return 0;
-        }
-        i_error(
-            "move mail failed: from namespace: %s to namespace %s: src_oid: %s, des_oid: %s, error_code : %d, "
-            "pool_name: %s",
-            ns_src.c_str(), ns_dest.c_str(), src_oid.c_str(), dest_oid.c_str(), ret_val,
-            rados_storage->get_pool_name().c_str());
-        FUNC_END_RET("ret == -1, rados_storage->move failed");
+      if (move_mail(ctx, rados_storage, mail, &ns_src, &ns_dest) < 0) {
         return -1;
       }
-
-      // set src as expunged
-      struct expunged_item *item = p_new(default_pool, struct expunged_item, 1);
-      i_zero(item);
-      guid_128_from_string(src_oid.c_str(), item->oid);
-      array_append(&rmailbox->moved_items, &item, 1);
-
-      rbox_move_index(ctx, mail);
-      if (r_storage->save_log->is_open()) {
-        std::list<librmb::RadosMetadata *> metadata;
-        librmb::RadosMetadata mailbox_guid(librmb::RBOX_METADATA_MAILBOX_GUID,
-                                           guid_128_to_string(rmailbox->mailbox_guid));
-        librmb::RadosMetadata mb_name(librmb::RBOX_METADATA_ORIG_MAILBOX, rmailbox->box.vname);
-
-        librmb::RadosMetadata uid(librmb::RBOX_METADATA_MAIL_UID, mail->uid);
-        librmb::RadosMetadata guid(librmb::RBOX_METADATA_GUID, guid_128_to_string(r_ctx->mail_guid));
-        metadata.push_back(&mailbox_guid);
-        metadata.push_back(&mb_name);
-        metadata.push_back(&uid);
-        metadata.push_back(&guid);
-
-        r_storage->save_log->append(librmb::RadosSaveLogEntry(
-            dest_oid, ns_dest, rados_storage->get_pool_name(),
-            librmb::RadosSaveLogEntry::op_mv(ns_src, src_oid, dest_mbox->list->ns->owner->username, metadata)));
-      }
-#ifdef DEBUG
-      i_debug("move successfully finished from %s (ns=%s) to %s (ns=%s)", src_oid.c_str(), ns_src.c_str(),
-              src_oid.c_str(), ns_dest.c_str());
-#endif
     }
     index_copy_cache_fields(ctx, mail, r_ctx->seq);
     if (ctx->dest_mail != NULL) {
@@ -287,7 +321,7 @@ static int rbox_mail_storage_try_copy(struct mail_save_context **_ctx, struct ma
     }
   }
   FUNC_END();
-  return ret_val;
+  return 0;
 }
 
 int rbox_mail_storage_copy(struct mail_save_context *ctx, struct mail *mail) {

--- a/src/storage-rbox/rbox-copy.cpp
+++ b/src/storage-rbox/rbox-copy.cpp
@@ -254,6 +254,7 @@ static int rbox_mail_storage_try_copy(struct mail_save_context **_ctx, struct ma
 
       // set src as expunged
       struct expunged_item *item = p_new(default_pool, struct expunged_item, 1);
+      i_zero(item);
       guid_128_from_string(src_oid.c_str(), item->oid);
       array_append(&rmailbox->moved_items, &item, 1);
 

--- a/src/storage-rbox/rbox-copy.cpp
+++ b/src/storage-rbox/rbox-copy.cpp
@@ -167,7 +167,7 @@ static int copy_mail(struct mail_save_context *ctx, librmb::RadosStorage *rados_
   struct rbox_storage *r_storage = (struct rbox_storage *)&r_ctx->mbox->storage->storage;
 
   std::list<librmb::RadosMetadata> metadata_update;
-  std::string src_oid = rmail->mail_object->get_oid();
+  std::string src_oid = rmail->rados_mail->get_oid();
 
   setup_mail_object(ctx);
 
@@ -217,7 +217,7 @@ static int move_mail(struct mail_save_context *ctx, librmb::RadosStorage *rados_
   struct mailbox *dest_mbox = ctx->transaction->box;
 
   std::list<librmb::RadosMetadata> metadata_update;
-  std::string src_oid = rmail->mail_object->get_oid();
+  std::string src_oid = rmail->rados_mail->get_oid();
   std::string dest_oid = src_oid;
 
   set_mailbox_metadata(ctx, &metadata_update);

--- a/src/storage-rbox/rbox-copy.cpp
+++ b/src/storage-rbox/rbox-copy.cpp
@@ -23,7 +23,7 @@ extern "C" {
 #include "ostream-private.h"
 #include "debug-helper.h"
 }
-#include "rados-mail-object.h"
+#include "../librmb/rados-mail.h"
 #include "rbox-storage.hpp"
 #include "rbox-mail.h"
 #include "rbox-save.h"
@@ -171,7 +171,7 @@ static int copy_mail(struct mail_save_context *ctx, librmb::RadosStorage *rados_
 
   setup_mail_object(ctx);
 
-  std::string dest_oid = r_ctx->current_object->get_oid();
+  std::string dest_oid = r_ctx->rados_mail->get_oid();
 
   set_mailbox_metadata(ctx, &metadata_update);
 
@@ -192,8 +192,8 @@ static int copy_mail(struct mail_save_context *ctx, librmb::RadosStorage *rados_
         ns_src->c_str(), ns_dest->c_str(), src_oid.c_str(), dest_oid.c_str(), ret_val,
         rados_storage->get_pool_name().c_str());
     FUNC_END_RET("ret == -1, rados_storage->copy failed");
-    rados_storage->free_mail_object(r_ctx->current_object);
-    r_ctx->current_object = nullptr;
+    rados_storage->free_rados_mail(r_ctx->rados_mail);
+    r_ctx->rados_mail = nullptr;
     return -1;
   }
 

--- a/src/storage-rbox/rbox-mail.cpp
+++ b/src/storage-rbox/rbox-mail.cpp
@@ -33,13 +33,13 @@ extern "C" {
 #include "limits.h"
 }
 
-#include "rados-mail-object.h"
+#include "../librmb/rados-mail.h"
 #include "rbox-storage.hpp"
 #include "../librmb/rados-storage-impl.h"
 #include "istream-bufferlist.h"
 #include "rbox-mail.h"
 
-using librmb::RadosMailObject;
+using librmb::RadosMail;
 using librmb::rbox_metadata_key;
 
 void rbox_mail_set_expunged(struct rbox_mail *mail) {
@@ -376,7 +376,7 @@ static int rbox_mail_get_stream(struct mail *_mail, bool get_body ATTR_UNUSED, s
     if (rmail->mail_object == nullptr) {
       // make sure that mail_object is initialized,
       // else create and load guid from index.
-      rmail->mail_object = rados_storage->alloc_mail_object();
+      rmail->mail_object = rados_storage->alloc_rados_mail();
       rbox_get_index_record(_mail);
     }
     rmail->mail_object->get_mail_buffer()->clear();
@@ -549,7 +549,7 @@ static void rbox_mail_close(struct mail *_mail) {
   struct rbox_storage *r_storage = (struct rbox_storage *)_mail->box->storage;
 
   if (rmail_->mail_object != nullptr) {
-    r_storage->s->free_mail_object(rmail_->mail_object);
+    r_storage->s->free_rados_mail(rmail_->mail_object);
     rmail_->mail_object = nullptr;
   }
 
@@ -564,7 +564,7 @@ static void rbox_index_mail_set_seq(struct mail *_mail, uint32_t seq, bool savin
 
   if (rmail_->mail_object == nullptr) {
     struct rbox_storage *r_storage = (struct rbox_storage *)_mail->box->storage;
-    rmail_->mail_object = r_storage->s->alloc_mail_object();
+    rmail_->mail_object = r_storage->s->alloc_rados_mail();
     rbox_get_index_record(_mail);
   }
 }

--- a/src/storage-rbox/rbox-mail.cpp
+++ b/src/storage-rbox/rbox-mail.cpp
@@ -71,7 +71,7 @@ int rbox_get_index_record(struct mail *_mail) {
 
     if (obox_rec == nullptr) {
       i_error("no index entry for %d, ext_id=%d ,mail_object->oid='%s'", _mail->seq, rbox->ext_id,
-              rmail->mail_object->get_oid().c_str());
+              rmail->rados_mail->get_oid().c_str());
       /* lost for some reason, give up */
       FUNC_END_RET("ret == -1");
       return -1;
@@ -80,7 +80,7 @@ int rbox_get_index_record(struct mail *_mail) {
     memcpy(rmail->index_guid, obox_rec->guid, sizeof(obox_rec->guid));
     memcpy(rmail->index_oid, obox_rec->oid, sizeof(obox_rec->oid));
 
-    rmail->mail_object->set_oid(guid_128_to_string(rmail->index_oid));
+    rmail->rados_mail->set_oid(guid_128_to_string(rmail->index_oid));
     rmail->last_seq = _mail->seq;
   }
   FUNC_END();
@@ -122,21 +122,21 @@ static int rbox_mail_metadata_get(struct rbox_mail *rmail, enum rbox_metadata_ke
   } else {
     r_storage->ms->get_storage()->set_io_ctx(&r_storage->s->get_io_ctx());
   }
-  int ret_load_metadata = r_storage->ms->get_storage()->load_metadata(rmail->mail_object);
+  int ret_load_metadata = r_storage->ms->get_storage()->load_metadata(rmail->rados_mail);
   if (ret_load_metadata < 0) {
     if (ret_load_metadata == -ENOENT) {
       i_warning("Errorcode: %d cannot get x_attr from object %s, process %d", ret_load_metadata,
-                rmail->mail_object->get_oid().c_str(), getpid());
+                rmail->rados_mail->get_oid().c_str(), getpid());
       rbox_mail_set_expunged(rmail);
     } else {
       i_error("Errorcode: %d cannot get x_attr from object %s, process %d", ret_load_metadata,
-              rmail->mail_object->get_oid().c_str(), getpid());
+              rmail->rados_mail->get_oid().c_str(), getpid());
     }
     FUNC_END();
     return -1;
   }
   std::string value;
-  rmail->mail_object->get_metadata(key, &value);
+  rmail->rados_mail->get_metadata(key, &value);
   if (!value.empty()) {
     *value_r = i_strdup(value.c_str());
   }
@@ -210,7 +210,7 @@ static int rbox_mail_get_save_date(struct mail *_mail, time_t *date_r) {
   }
 
   librmb::RadosStorage *rados_storage = alt_storage ? r_storage->alt : r_storage->s;
-  int ret_val = rados_storage->stat_mail(rmail->mail_object->get_oid(), &object_size, &save_date_rados);
+  int ret_val = rados_storage->stat_mail(rmail->rados_mail->get_oid(), &object_size, &save_date_rados);
   if (ret_val < 0) {
     if (ret_val == -ENOENT) {
       rbox_mail_set_expunged(rmail);
@@ -223,7 +223,7 @@ static int rbox_mail_get_save_date(struct mail *_mail, time_t *date_r) {
   if (save_date_rados == 0) {
     // last chance is to stat the object to get the save date.
     uint64_t psize;
-    if (rados_storage->stat_mail(rmail->mail_object->get_oid(), &psize, &save_date_rados) < 0) {
+    if (rados_storage->stat_mail(rmail->rados_mail->get_oid(), &psize, &save_date_rados) < 0) {
       // at least it needs to exist?
       return -1;
     }
@@ -249,7 +249,7 @@ int rbox_mail_get_virtual_size(struct mail *_mail, uoff_t *size_r) {
   if (index_mail_get_cached_virtual_size(&rmail->imail, size_r) && *size_r > 0) {
     return 0;
   }
-  if (rmail->mail_object == nullptr) {
+  if (rmail->rados_mail == nullptr) {
     // Mail already deleted
     FUNC_END_RET("ret == -1; mail_object == nullptr ");
     return -1;
@@ -293,7 +293,7 @@ static int rbox_mail_get_physical_size(struct mail *_mail, uoff_t *size_r) {
     return 0;
   }
 
-  if (rmail->mail_object == nullptr) {
+  if (rmail->rados_mail == nullptr) {
     // Mail already deleted
     FUNC_END_RET("ret == -1; mail_object == nullptr ");
     return -1;
@@ -315,7 +315,7 @@ static int rbox_mail_get_physical_size(struct mail *_mail, uoff_t *size_r) {
     librmb::RadosStorage *rados_storage = alt_storage ? r_storage->alt : r_storage->s;
     uint64_t psize;
     time_t pmtime;
-    if (rados_storage->stat_mail(rmail->mail_object->get_oid(), &psize, &pmtime) < 0) {
+    if (rados_storage->stat_mail(rmail->rados_mail->get_oid(), &psize, &pmtime) < 0) {
       // at least it needs to exists?
       return -1;
     }
@@ -373,25 +373,25 @@ static int rbox_mail_get_stream(struct mail *_mail, bool get_body ATTR_UNUSED, s
       rados_storage->set_namespace(rados_storage->get_namespace());
     }
 
-    if (rmail->mail_object == nullptr) {
+    if (rmail->rados_mail == nullptr) {
       // make sure that mail_object is initialized,
       // else create and load guid from index.
-      rmail->mail_object = rados_storage->alloc_rados_mail();
+      rmail->rados_mail = rados_storage->alloc_rados_mail();
       rbox_get_index_record(_mail);
     }
-    rmail->mail_object->get_mail_buffer()->clear();
+    rmail->rados_mail->get_mail_buffer()->clear();
 
     _mail->transaction->stats.open_lookup_count++;
-    int physical_size = rados_storage->read_mail(rmail->mail_object->get_oid(), rmail->mail_object->get_mail_buffer());
+    int physical_size = rados_storage->read_mail(rmail->rados_mail->get_oid(), rmail->rados_mail->get_mail_buffer());
     if (physical_size < 0) {
       if (physical_size == -ENOENT) {
-        i_warning("Mail not found. %s, ns='%s', process %d", rmail->mail_object->get_oid().c_str(),
+        i_warning("Mail not found. %s, ns='%s', process %d", rmail->rados_mail->get_oid().c_str(),
                   rados_storage->get_namespace().c_str(), getpid());
         rbox_mail_set_expunged(rmail);
         FUNC_END_RET("ret == -1");
         return -1;
       } else {
-        i_error("reading mail return code: %d, oid: %s", physical_size, rmail->mail_object->get_oid().c_str());
+        i_error("reading mail return code: %d, oid: %s", physical_size, rmail->rados_mail->get_oid().c_str());
         FUNC_END_RET("ret == -1");
         return -1;
       }
@@ -408,7 +408,7 @@ static int rbox_mail_get_stream(struct mail *_mail, bool get_body ATTR_UNUSED, s
       return -1;
     }
 
-    if (get_mail_stream(rmail, rmail->mail_object->get_mail_buffer(), physical_size, &input) < 0) {
+    if (get_mail_stream(rmail, rmail->rados_mail->get_mail_buffer(), physical_size, &input) < 0) {
       FUNC_END_RET("ret == -1");
       return -1;
     }
@@ -548,9 +548,9 @@ static void rbox_mail_close(struct mail *_mail) {
   struct rbox_mail *rmail_ = (struct rbox_mail *)_mail;
   struct rbox_storage *r_storage = (struct rbox_storage *)_mail->box->storage;
 
-  if (rmail_->mail_object != nullptr) {
-    r_storage->s->free_rados_mail(rmail_->mail_object);
-    rmail_->mail_object = nullptr;
+  if (rmail_->rados_mail != nullptr) {
+    r_storage->s->free_rados_mail(rmail_->rados_mail);
+    rmail_->rados_mail = nullptr;
   }
 
   index_mail_close(_mail);
@@ -562,9 +562,9 @@ static void rbox_index_mail_set_seq(struct mail *_mail, uint32_t seq, bool savin
   // close mail and set sequence
   index_mail_set_seq(_mail, seq, saving);
 
-  if (rmail_->mail_object == nullptr) {
+  if (rmail_->rados_mail == nullptr) {
     struct rbox_storage *r_storage = (struct rbox_storage *)_mail->box->storage;
-    rmail_->mail_object = r_storage->s->alloc_rados_mail();
+    rmail_->rados_mail = r_storage->s->alloc_rados_mail();
     rbox_get_index_record(_mail);
   }
 }

--- a/src/storage-rbox/rbox-mail.h
+++ b/src/storage-rbox/rbox-mail.h
@@ -13,8 +13,8 @@
 #define SRC_STORAGE_RBOX_RBOX_MAIL_H_
 
 #include "index-mail.h"
-#include "rados-mail-object.h"
 #include <rados/librados.hpp>
+#include "../librmb/rados-mail.h"
 
 struct rbox_mail {
   struct index_mail imail;
@@ -22,7 +22,7 @@ struct rbox_mail {
   guid_128_t index_guid;
   guid_128_t index_oid;
 
-  librmb::RadosMailObject *mail_object;
+  librmb::RadosMail *mail_object;
   uint32_t last_seq;  // TODO(jrse): init with -1
 };
 extern void rbox_mail_set_expunged(struct rbox_mail *mail);

--- a/src/storage-rbox/rbox-mail.h
+++ b/src/storage-rbox/rbox-mail.h
@@ -22,7 +22,7 @@ struct rbox_mail {
   guid_128_t index_guid;
   guid_128_t index_oid;
 
-  librmb::RadosMail *mail_object;
+  librmb::RadosMail *rados_mail;
   uint32_t last_seq;  // TODO(jrse): init with -1
 };
 extern void rbox_mail_set_expunged(struct rbox_mail *mail);

--- a/src/storage-rbox/rbox-save.cpp
+++ b/src/storage-rbox/rbox-save.cpp
@@ -101,9 +101,9 @@ void rbox_add_to_index(struct mail_save_context *_ctx) {
 /* add to index */
 #if DOVECOT_PREREQ(2, 3)
   if ((r_ctx->ctx.transaction->flags & MAILBOX_TRANSACTION_FLAG_FILL_IN_STUB) == 0) {
-    mail_index_append(r_ctx->trans, mdata->uid, &r_ctx->seq);
+    mail_index_append(r_ctx->trans, _ctx->data.uid, &r_ctx->seq);
   } else {
-    r_ctx->seq = mdata->stub_seq;
+    r_ctx->seq = _ctx->data.stub_seq;
   }
 #else
   mail_index_append(r_ctx->trans, _ctx->data.uid, &r_ctx->seq);

--- a/src/storage-rbox/rbox-save.cpp
+++ b/src/storage-rbox/rbox-save.cpp
@@ -156,7 +156,7 @@ void rbox_move_index(struct mail_save_context *_ctx, struct mail *src_mail) {
   struct rbox_mail *r_src_mail = (struct rbox_mail *)src_mail;
 #endif
 
-  guid_128_from_string(r_src_mail->mail_object->get_oid().c_str(), r_ctx->mail_oid);
+  guid_128_from_string(r_src_mail->rados_mail->get_oid().c_str(), r_ctx->mail_oid);
 
   r_ctx->rados_mail = r_storage->s->alloc_rados_mail();
   r_ctx->rados_mail->set_oid(guid_128_to_string(r_ctx->mail_oid));

--- a/src/storage-rbox/rbox-save.h
+++ b/src/storage-rbox/rbox-save.h
@@ -71,4 +71,6 @@ void rbox_move_index(struct mail_save_context *_ctx, struct mail *src_mail);
 void init_output_stream(mail_save_context *_ctx);
 int allocate_mail_buffer(mail_save_context *_ctx, int &initial_mail_buffer_size);
 void clean_up_mail_object_list(struct rbox_save_context *r_ctx, struct rbox_storage *r_storage);
+void rbox_save_update_header_flags(struct rbox_save_context *ctx, struct mail_index_view *sync_view, uint32_t ext_id,
+                                   unsigned int flags_offset);
 #endif  // SRC_STORAGE_RBOX_RBOX_SAVE_H_

--- a/src/storage-rbox/rbox-save.h
+++ b/src/storage-rbox/rbox-save.h
@@ -18,7 +18,7 @@
 #include "../librmb/rados-storage-impl.h"
 #include "mail-storage-private.h"
 
-#include "rados-mail-object.h"
+#include "../librmb/rados-mail.h"
 
 class rbox_save_context {
  public:
@@ -32,7 +32,7 @@ class rbox_save_context {
         input(NULL),
         output_stream(NULL),
         rados_storage(_rados_storage),
-        current_object(NULL),
+        rados_mail(NULL),
         failed(1),
         finished(1),
         copying(0),
@@ -56,8 +56,8 @@ class rbox_save_context {
   struct ostream *output_stream;
 
   const librmb::RadosStorage &rados_storage;
-  std::vector<librmb::RadosMailObject *> objects;
-  librmb::RadosMailObject *current_object;
+  std::vector<librmb::RadosMail *> rados_mails;
+  librmb::RadosMail *rados_mail;
 
   unsigned int failed : 1;
   unsigned int finished : 1;

--- a/src/storage-rbox/rbox-save.h
+++ b/src/storage-rbox/rbox-save.h
@@ -71,6 +71,7 @@ void rbox_move_index(struct mail_save_context *_ctx, struct mail *src_mail);
 void init_output_stream(mail_save_context *_ctx);
 int allocate_mail_buffer(mail_save_context *_ctx, int &initial_mail_buffer_size);
 void clean_up_mail_object_list(struct rbox_save_context *r_ctx, struct rbox_storage *r_storage);
-void rbox_save_update_header_flags(struct rbox_save_context *ctx, struct mail_index_view *sync_view, uint32_t ext_id,
+void rbox_save_update_header_flags(struct rbox_save_context *r_ctx, struct mail_index_view *sync_view, uint32_t ext_id,
                                    unsigned int flags_offset);
+void rbox_index_append(struct mail_save_context *_ctx);
 #endif  // SRC_STORAGE_RBOX_RBOX_SAVE_H_

--- a/src/storage-rbox/rbox-storage.cpp
+++ b/src/storage-rbox/rbox-storage.cpp
@@ -361,7 +361,7 @@ int read_plugin_configuration(struct mailbox *box) {
 #ifdef DEBUG
       struct rbox_mailbox *rbox = (struct rbox_mailbox *)box;
       i_debug("reading plugin conf: %s=%s", setting.c_str(),
-              mail_user_plugin_getenv(rbox->r_storage->storage.user, setting.c_str()));
+              mail_user_plugin_getenv(rbox->storage->storage.user, setting.c_str()));
 #endif
     }
     r_storage->config->set_config_valid(true);

--- a/src/storage-rbox/rbox-storage.cpp
+++ b/src/storage-rbox/rbox-storage.cpp
@@ -361,7 +361,7 @@ int read_plugin_configuration(struct mailbox *box) {
 #ifdef DEBUG
       struct rbox_mailbox *rbox = (struct rbox_mailbox *)box;
       i_debug("reading plugin conf: %s=%s", setting.c_str(),
-              mail_user_plugin_getenv(rbox->r_storage->r_storage.user, setting.c_str()));
+              mail_user_plugin_getenv(rbox->r_storage->storage.user, setting.c_str()));
 #endif
     }
     r_storage->config->set_config_valid(true);

--- a/src/storage-rbox/rbox-storage.cpp
+++ b/src/storage-rbox/rbox-storage.cpp
@@ -60,6 +60,7 @@ struct mail_storage *rbox_storage_alloc(void) {
   pool_t pool;
   pool = pool_alloconly_create("rbox storage", 256);
   storage = p_new(pool, struct rbox_storage, 1);
+  i_zero(storage);
   storage->storage = rbox_storage;
   storage->storage.pool = pool;
   storage->cluster = new librmb::RadosClusterImpl();
@@ -75,7 +76,6 @@ struct mail_storage *rbox_storage_alloc(void) {
   FUNC_END();
   return &storage->storage;
 }
-
 
 void rbox_storage_get_list_settings(const struct mail_namespace *ns ATTR_UNUSED, struct mailbox_list_settings *set) {
   FUNC_START();
@@ -101,7 +101,7 @@ static const char *rbox_storage_find_root_dir(const struct mail_namespace *ns) {
     const char *path = t_strconcat(home, "/rbox", NULL);
     if (access(path, R_OK | W_OK | X_OK) == 0) {
 #ifdef DEBUG
-        i_debug("rbox: root exists (%s)", path);
+      i_debug("rbox: root exists (%s)", path);
 #endif
       return path;
     }
@@ -219,6 +219,7 @@ struct mailbox *rbox_mailbox_alloc(struct mail_storage *storage, struct mailbox_
 
   pool = pool_alloconly_create("rbox mailbox", 1024);
   rbox = p_new(pool, struct rbox_mailbox, 1);
+  i_zero(rbox);
   rbox_mailbox.v = rbox_mailbox_vfuncs;
   rbox->box = rbox_mailbox;
   rbox->box.pool = pool;
@@ -432,8 +433,6 @@ int rbox_open_rados_connection(struct mailbox *box, bool alt_storage) {
   FUNC_END();
   return ret;
 }
-
-
 
 static void rbox_update_header(struct rbox_mailbox *mbox, struct mail_index_transaction *trans,
                                const struct mailbox_update *update) {

--- a/src/storage-rbox/rbox-storage.cpp
+++ b/src/storage-rbox/rbox-storage.cpp
@@ -56,25 +56,25 @@ extern struct mailbox_vfuncs rbox_mailbox_vfuncs;
 
 struct mail_storage *rbox_storage_alloc(void) {
   FUNC_START();
-  struct rbox_storage *storage;
+  struct rbox_storage *r_storage;
   pool_t pool;
   pool = pool_alloconly_create("rbox storage", 256);
-  storage = p_new(pool, struct rbox_storage, 1);
-  i_zero(storage);
-  storage->storage = rbox_storage;
-  storage->storage.pool = pool;
-  storage->cluster = new librmb::RadosClusterImpl();
-  storage->s = new librmb::RadosStorageImpl(storage->cluster);
-  storage->config = new librmb::RadosDovecotCephCfgImpl(&storage->s->get_io_ctx());
-  storage->ns_mgr = new librmb::RadosNamespaceManager(storage->config);
-  storage->ms = new librmb::RadosMetadataStorageImpl();
-  storage->alt = new librmb::RadosStorageImpl(storage->cluster);
+  r_storage = p_new(pool, struct rbox_storage, 1);
+  i_zero(r_storage);
+  r_storage->storage = rbox_storage;
+  r_storage->storage.pool = pool;
+  r_storage->cluster = new librmb::RadosClusterImpl();
+  r_storage->s = new librmb::RadosStorageImpl(r_storage->cluster);
+  r_storage->config = new librmb::RadosDovecotCephCfgImpl(&r_storage->s->get_io_ctx());
+  r_storage->ns_mgr = new librmb::RadosNamespaceManager(r_storage->config);
+  r_storage->ms = new librmb::RadosMetadataStorageImpl();
+  r_storage->alt = new librmb::RadosStorageImpl(r_storage->cluster);
 
   // logfile is set when 90-plugin.conf param rados_save_cfg is evaluated.
-  storage->save_log = new librmb::RadosSaveLog();
+  r_storage->save_log = new librmb::RadosSaveLog();
 
   FUNC_END();
-  return &storage->storage;
+  return &r_storage->storage;
 }
 
 void rbox_storage_get_list_settings(const struct mail_namespace *ns ATTR_UNUSED, struct mailbox_list_settings *set) {
@@ -172,42 +172,42 @@ int rbox_storage_create(struct mail_storage *_storage, struct mail_namespace *ns
 
 void rbox_storage_destroy(struct mail_storage *_storage) {
   FUNC_START();
-  struct rbox_storage *storage = (struct rbox_storage *)_storage;
+  struct rbox_storage *r_storage = (struct rbox_storage *)_storage;
 
-  if (storage->s != nullptr) {
-    storage->s->close_connection();
-    delete storage->s;
-    storage->s = nullptr;
+  if (r_storage->s != nullptr) {
+    r_storage->s->close_connection();
+    delete r_storage->s;
+    r_storage->s = nullptr;
   }
-  if (storage->alt != nullptr) {
-    storage->alt->close_connection();
-    delete storage->alt;
-    storage->alt = nullptr;
+  if (r_storage->alt != nullptr) {
+    r_storage->alt->close_connection();
+    delete r_storage->alt;
+    r_storage->alt = nullptr;
   }
-  if (storage->cluster != nullptr) {
-    storage->cluster->deinit();
-    delete storage->cluster;
-    storage->cluster = nullptr;
+  if (r_storage->cluster != nullptr) {
+    r_storage->cluster->deinit();
+    delete r_storage->cluster;
+    r_storage->cluster = nullptr;
   }
 
-  if (storage->ns_mgr != nullptr) {
-    delete storage->ns_mgr;
-    storage->ns_mgr = nullptr;
+  if (r_storage->ns_mgr != nullptr) {
+    delete r_storage->ns_mgr;
+    r_storage->ns_mgr = nullptr;
   }
-  if (storage->config != nullptr) {
-    delete storage->config;
-    storage->config = nullptr;
+  if (r_storage->config != nullptr) {
+    delete r_storage->config;
+    r_storage->config = nullptr;
   }
-  if (storage->ms != nullptr) {
-    delete storage->ms;
-    storage->ms = nullptr;
+  if (r_storage->ms != nullptr) {
+    delete r_storage->ms;
+    r_storage->ms = nullptr;
   }
-  if (storage->save_log != nullptr) {
-    if (!storage->save_log->close()) {
+  if (r_storage->save_log != nullptr) {
+    if (!r_storage->save_log->close()) {
       i_warning("unable to close save log file");
     }
-    delete storage->save_log;
-    storage->save_log = nullptr;
+    delete r_storage->save_log;
+    r_storage->save_log = nullptr;
   }
   index_storage_destroy(_storage);
 
@@ -250,42 +250,42 @@ struct mailbox *rbox_mailbox_alloc(struct mail_storage *storage, struct mailbox_
   return &rbox->box;
 }
 
-static int rbox_mailbox_alloc_index(struct rbox_mailbox *mbox) {
+static int rbox_mailbox_alloc_index(struct rbox_mailbox *rbox) {
   FUNC_START();
 
-  if (index_storage_mailbox_alloc_index(&mbox->box) < 0)
+  if (index_storage_mailbox_alloc_index(&rbox->box) < 0)
     return -1;
 
-  mbox->hdr_ext_id = mail_index_ext_register(mbox->box.index, "dbox-hdr", sizeof(struct sdbox_index_header), 0, 0);
+  rbox->hdr_ext_id = mail_index_ext_register(rbox->box.index, "dbox-hdr", sizeof(struct sdbox_index_header), 0, 0);
   /* set the initialization data in case the mailbox is created */
   struct sdbox_index_header hdr;
   i_zero(&hdr);
   guid_128_generate(hdr.mailbox_guid);
-  mail_index_set_ext_init_data(mbox->box.index, mbox->hdr_ext_id, &hdr, sizeof(hdr));
+  mail_index_set_ext_init_data(rbox->box.index, rbox->hdr_ext_id, &hdr, sizeof(hdr));
 
-  memcpy(mbox->mailbox_guid, hdr.mailbox_guid, sizeof(mbox->mailbox_guid));
+  memcpy(rbox->mailbox_guid, hdr.mailbox_guid, sizeof(rbox->mailbox_guid));
 
   // register index record holding the mail guid
-  mbox->ext_id = mail_index_ext_register(mbox->box.index, "obox", 0, sizeof(struct obox_mail_index_record), 1);
+  rbox->ext_id = mail_index_ext_register(rbox->box.index, "obox", 0, sizeof(struct obox_mail_index_record), 1);
   FUNC_END();
   return 0;
 }
 
-int rbox_read_header(struct rbox_mailbox *mbox, struct sdbox_index_header *hdr, bool log_error, bool *need_resize_r) {
+int rbox_read_header(struct rbox_mailbox *rbox, struct sdbox_index_header *hdr, bool log_error, bool *need_resize_r) {
   FUNC_START();
   struct mail_index_view *view;
   const void *data;
   size_t data_size;
   int ret = 0;
 
-  i_assert(mbox->box.opened);
+  i_assert(rbox->box.opened);
 
-  view = mail_index_view_open(mbox->box.index);
-  mail_index_get_header_ext(view, mbox->hdr_ext_id, &data, &data_size);
-  if (data_size < SDBOX_INDEX_HEADER_MIN_SIZE && (!mbox->box.creating || data_size != 0)) {
+  view = mail_index_view_open(rbox->box.index);
+  mail_index_get_header_ext(view, rbox->hdr_ext_id, &data, &data_size);
+  if (data_size < SDBOX_INDEX_HEADER_MIN_SIZE && (!rbox->box.creating || data_size != 0)) {
     if (log_error) {
-      mail_storage_set_critical(&mbox->storage->storage, "sdbox %s: Invalid dbox header size",
-                                mailbox_get_path(&mbox->box));
+      mail_storage_set_critical(&rbox->storage->storage, "sdbox %s: Invalid dbox header size",
+                                mailbox_get_path(&rbox->box));
     }
     ret = -1;
   } else {
@@ -299,7 +299,7 @@ int rbox_read_header(struct rbox_mailbox *mbox, struct sdbox_index_header *hdr, 
     } else {
       /* data is valid. remember it in case mailbox
          is being reset */
-      mail_index_set_ext_init_data(mbox->box.index, mbox->hdr_ext_id, hdr, sizeof(*hdr));
+      mail_index_set_ext_init_data(rbox->box.index, rbox->hdr_ext_id, hdr, sizeof(*hdr));
     }
   }
   mail_index_view_close(&view);
@@ -341,9 +341,9 @@ static int rbox_open_mailbox(struct mailbox *box) {
       box->index, box->storage->set->parsed_fsync_mode,
       static_cast<mail_index_fsync_mask>(MAIL_INDEX_FSYNC_MASK_APPENDS | MAIL_INDEX_FSYNC_MASK_EXPUNGES));
 
-  struct rbox_mailbox *mbox = (struct rbox_mailbox *)box;
-  if (!array_is_created(&mbox->moved_items)) {
-    i_array_init(&mbox->moved_items, 32);
+  struct rbox_mailbox *rbox = (struct rbox_mailbox *)box;
+  if (!array_is_created(&rbox->moved_items)) {
+    i_array_init(&rbox->moved_items, 32);
   }
   FUNC_END();
 
@@ -351,23 +351,23 @@ static int rbox_open_mailbox(struct mailbox *box) {
 }
 int read_plugin_configuration(struct mailbox *box) {
   FUNC_START();
-  struct rbox_mailbox *mbox = (struct rbox_mailbox *)box;
-  struct rbox_storage *storage = (struct rbox_storage *)box->storage;
+  struct rbox_storage *r_storage = (struct rbox_storage *)box->storage;
 
-  if (!storage->config->is_config_valid()) {
-    std::map<std::string, std::string> *map = storage->config->get_config();
+  if (!r_storage->config->is_config_valid()) {
+    std::map<std::string, std::string> *map = r_storage->config->get_config();
     for (std::map<std::string, std::string>::iterator it = map->begin(); it != map->end(); ++it) {
       std::string setting = it->first;
-      storage->config->update_metadata(setting, mail_user_plugin_getenv(storage->storage.user, setting.c_str()));
+      r_storage->config->update_metadata(setting, mail_user_plugin_getenv(r_storage->storage.user, setting.c_str()));
 #ifdef DEBUG
+      struct rbox_mailbox *rbox = (struct rbox_mailbox *)box;
       i_debug("reading plugin conf: %s=%s", setting.c_str(),
-              mail_user_plugin_getenv(mbox->storage->storage.user, setting.c_str()));
+              mail_user_plugin_getenv(rbox->r_storage->r_storage.user, setting.c_str()));
 #endif
     }
-    storage->config->set_config_valid(true);
-    storage->save_log->set_save_log_file(storage->config->get_rados_save_log_file());
-    if (!storage->save_log->open() && !storage->config->get_rados_save_log_file().empty()) {
-      i_warning("unable to open the rados save log file %s", storage->config->get_rados_save_log_file().c_str());
+    r_storage->config->set_config_valid(true);
+    r_storage->save_log->set_save_log_file(r_storage->config->get_rados_save_log_file());
+    if (!r_storage->save_log->open() && !r_storage->config->get_rados_save_log_file().empty()) {
+      i_warning("unable to open the rados save log file %s", r_storage->config->get_rados_save_log_file().c_str());
     }
   }
   FUNC_END();
@@ -383,18 +383,18 @@ bool is_alternate_pool_valid(struct mailbox *_box) {
 int rbox_open_rados_connection(struct mailbox *box, bool alt_storage) {
   FUNC_START();
   /* rados cluster connection */
-  struct rbox_mailbox *mbox = (struct rbox_mailbox *)box;
-  librmb::RadosStorage *rados_storage = mbox->storage->s;
+  struct rbox_mailbox *rbox = (struct rbox_mailbox *)box;
+  librmb::RadosStorage *rados_storage = rbox->storage->s;
 
   // initialize storage with plugin configuration
   read_plugin_configuration(box);
-  int ret = rados_storage->open_connection(mbox->storage->config->get_pool_name(),
-                                           mbox->storage->config->get_rados_cluster_name(),
-                                           mbox->storage->config->get_rados_username());
+  int ret = rados_storage->open_connection(rbox->storage->config->get_pool_name(),
+                                           rbox->storage->config->get_rados_cluster_name(),
+                                           rbox->storage->config->get_rados_username());
 
   if (alt_storage) {
-    ret = mbox->storage->alt->open_connection(box->list->set.alt_dir, mbox->storage->config->get_rados_cluster_name(),
-                                              mbox->storage->config->get_rados_username());
+    ret = rbox->storage->alt->open_connection(box->list->set.alt_dir, rbox->storage->config->get_rados_cluster_name(),
+                                              rbox->storage->config->get_rados_username());
   }
   /*TODO:*/
   if (ret == 1) {
@@ -407,32 +407,32 @@ int rbox_open_rados_connection(struct mailbox *box, bool alt_storage) {
     return ret;
   }
   // load rados configuration
-  ret = mbox->storage->config->load_rados_config();
+  ret = rbox->storage->config->load_rados_config();
   if (ret == -ENOENT) {  // config does not exist.
-    ret = mbox->storage->config->save_default_rados_config();
+    ret = rbox->storage->config->save_default_rados_config();
   }
   if (ret < 0) {
     i_error("unable to read rados_config return value : %d", ret);
     return ret;
   }
-  mbox->storage->ms->create_metadata_storage(&mbox->storage->s->get_io_ctx(), mbox->storage->config);
+  rbox->storage->ms->create_metadata_storage(&rbox->storage->s->get_io_ctx(), rbox->storage->config);
 
   std::string uid;
   if (box->list->ns->owner != nullptr) {
     uid = box->list->ns->owner->username;
-    uid += mbox->storage->config->get_user_suffix();
+    uid += rbox->storage->config->get_user_suffix();
   } else {
-    uid = mbox->storage->config->get_public_namespace();
+    uid = rbox->storage->config->get_public_namespace();
   }
   std::string ns;
-  if (!mbox->storage->ns_mgr->lookup_key(uid, &ns)) {
+  if (!rbox->storage->ns_mgr->lookup_key(uid, &ns)) {
     RboxGuidGenerator guid_generator;
-    ret = mbox->storage->ns_mgr->add_namespace_entry(uid, &ns, &guid_generator) ? 0 : -1;
+    ret = rbox->storage->ns_mgr->add_namespace_entry(uid, &ns, &guid_generator) ? 0 : -1;
   }
   if (ret >= 0) {
     rados_storage->set_namespace(ns);
     if (alt_storage) {
-      mbox->storage->alt->set_namespace(ns);
+      rbox->storage->alt->set_namespace(ns);
     }
   } else {
     i_error("error namespace not set: for uid %s error code is: %d", uid.c_str(), ret);
@@ -441,14 +441,14 @@ int rbox_open_rados_connection(struct mailbox *box, bool alt_storage) {
   return ret;
 }
 
-static void rbox_update_header(struct rbox_mailbox *mbox, struct mail_index_transaction *trans,
+static void rbox_update_header(struct rbox_mailbox *rbox, struct mail_index_transaction *trans,
                                const struct mailbox_update *update) {
   FUNC_START();
 
   struct sdbox_index_header hdr, new_hdr;
   bool need_resize;
 
-  if (rbox_read_header(mbox, &hdr, TRUE, &need_resize) < 0) {
+  if (rbox_read_header(rbox, &hdr, TRUE, &need_resize) < 0) {
     memset(&hdr, 0, sizeof(hdr));
     need_resize = TRUE;
   }
@@ -462,12 +462,12 @@ static void rbox_update_header(struct rbox_mailbox *mbox, struct mail_index_tran
   }
 
   if (need_resize) {
-    mail_index_ext_resize_hdr(trans, mbox->hdr_ext_id, sizeof(new_hdr));
+    mail_index_ext_resize_hdr(trans, rbox->hdr_ext_id, sizeof(new_hdr));
   }
   if (memcmp(&hdr, &new_hdr, sizeof(hdr)) != 0) {
-    mail_index_update_header_ext(trans, mbox->hdr_ext_id, 0, &new_hdr, sizeof(new_hdr));
+    mail_index_update_header_ext(trans, rbox->hdr_ext_id, 0, &new_hdr, sizeof(new_hdr));
   }
-  memcpy(mbox->mailbox_guid, new_hdr.mailbox_guid, sizeof(mbox->mailbox_guid));
+  memcpy(rbox->mailbox_guid, new_hdr.mailbox_guid, sizeof(rbox->mailbox_guid));
   FUNC_END();
 }
 
@@ -551,13 +551,13 @@ int rbox_mailbox_create_indexes(struct mailbox *box, const struct mailbox_update
 }
 int rbox_mailbox_open(struct mailbox *box) {
   FUNC_START();
-  struct rbox_mailbox *mbox = (struct rbox_mailbox *)box;
+  struct rbox_mailbox *rbox = (struct rbox_mailbox *)box;
   struct sdbox_index_header hdr;
   bool need_resize;
 
-  if (rbox_mailbox_alloc_index(mbox) < 0){
+  if (rbox_mailbox_alloc_index(rbox) < 0) {
     FUNC_END();
-	return -1;
+    return -1;
   }
 
   if (rbox_open_mailbox(box) < 0) {
@@ -572,21 +572,21 @@ int rbox_mailbox_open(struct mailbox *box) {
   }
 
   /* get/generate mailbox guid */
-  if (rbox_read_header(mbox, &hdr, FALSE, &need_resize) < 0) {
+  if (rbox_read_header(rbox, &hdr, FALSE, &need_resize) < 0) {
     /* looks like the mailbox is corrupted */
-    (void)rbox_sync(mbox, RBOX_SYNC_FLAG_FORCE);
-    if (rbox_read_header(mbox, &hdr, TRUE, &need_resize) < 0)
+    (void)rbox_sync(rbox, RBOX_SYNC_FLAG_FORCE);
+    if (rbox_read_header(rbox, &hdr, TRUE, &need_resize) < 0)
       i_zero(&hdr);
   }
 
   if (guid_128_is_empty(hdr.mailbox_guid)) {
     /* regenerate it */
-    if (rbox_mailbox_create_indexes(box, NULL, NULL) < 0 || rbox_read_header(mbox, &hdr, TRUE, &need_resize) < 0) {
+    if (rbox_mailbox_create_indexes(box, NULL, NULL) < 0 || rbox_read_header(rbox, &hdr, TRUE, &need_resize) < 0) {
       return -1;
     }
   }
 
-  memcpy(mbox->mailbox_guid, hdr.mailbox_guid, sizeof(mbox->mailbox_guid));
+  memcpy(rbox->mailbox_guid, hdr.mailbox_guid, sizeof(rbox->mailbox_guid));
   FUNC_END();
   return 0;
 }
@@ -594,18 +594,18 @@ int rbox_mailbox_open(struct mailbox *box) {
 void rbox_set_mailbox_corrupted(struct mailbox *box) {
   FUNC_START();
 
-  struct rbox_mailbox *mbox = (struct rbox_mailbox *)box;
+  struct rbox_mailbox *rbox = (struct rbox_mailbox *)box;
   struct sdbox_index_header hdr;
   bool need_resize;
 
-  if (rbox_read_header(mbox, &hdr, TRUE, &need_resize) < 0 || hdr.rebuild_count == 0)
-    mbox->storage->corrupted_rebuild_count = 1;
+  if (rbox_read_header(rbox, &hdr, TRUE, &need_resize) < 0 || hdr.rebuild_count == 0)
+    rbox->storage->corrupted_rebuild_count = 1;
   else
-    mbox->storage->corrupted_rebuild_count = hdr.rebuild_count;
+    rbox->storage->corrupted_rebuild_count = hdr.rebuild_count;
 
-  mbox->storage->corrupted = TRUE;
+  rbox->storage->corrupted = TRUE;
 #ifdef DEBUG
-  i_debug("setting currupted rebuild count to : %d", mbox->storage->corrupted_rebuild_count);
+  i_debug("setting currupted rebuild count to : %d", rbox->storage->corrupted_rebuild_count);
 #endif
   FUNC_END();
 }
@@ -700,8 +700,8 @@ int rbox_mailbox_create(struct mailbox *box, const struct mailbox_update *update
     if (ret < 0)
       return -1;
     if (ret == 0) {
-      struct rbox_storage *storage = (struct rbox_storage *)box->storage;
-      mail_storage_set_critical(&storage->storage,
+      struct rbox_storage *r_storage = (struct rbox_storage *)box->storage;
+      mail_storage_set_critical(&r_storage->storage,
                                 "Mailbox %s has existing files in alt path, "
                                 "rebuilding storage to avoid losing messages",
                                 box->vname);
@@ -745,8 +745,8 @@ int rbox_mailbox_get_metadata(struct mailbox *box, enum mailbox_metadata_items i
   }
 
   if ((items & MAILBOX_METADATA_GUID) != 0) {
-    struct rbox_mailbox *mbox = (struct rbox_mailbox *)box;
-    memcpy(metadata_r->guid, mbox->mailbox_guid, sizeof(metadata_r->guid));
+    struct rbox_mailbox *rbox = (struct rbox_mailbox *)box;
+    memcpy(metadata_r->guid, rbox->mailbox_guid, sizeof(metadata_r->guid));
   }
 
 #ifdef DEBUG
@@ -834,10 +834,10 @@ int rbox_storage_mailbox_delete(struct mailbox *box) {
     i_error("while processing index_storage_mailbox_delete: %d", ret);
     return ret;
   }
-  struct rbox_storage *storage = (struct rbox_storage *)box->storage;
+  struct rbox_storage *r_storage = (struct rbox_storage *)box->storage;
   // 90 plugin konfigurierbar!
   read_plugin_configuration(box);
-  if (!storage->config->is_rbox_check_empty_mailboxes()) {
+  if (!r_storage->config->is_rbox_check_empty_mailboxes()) {
     return ret;
   }
 
@@ -846,11 +846,11 @@ int rbox_storage_mailbox_delete(struct mailbox *box) {
     i_error("Opening rados connection : %d", ret);
     return ret;
   }
-  if (storage->config->is_user_mapping()) {  //
+  if (r_storage->config->is_user_mapping()) {  //
 
-    struct rbox_mailbox *mbox = (struct rbox_mailbox *)box;
-    ret =
-        check_users_mailbox_delete_ns_object(mbox->storage->storage.user, storage->config, storage->ns_mgr, storage->s);
+    struct rbox_mailbox *rbox = (struct rbox_mailbox *)box;
+    ret = check_users_mailbox_delete_ns_object(rbox->storage->storage.user, r_storage->config, r_storage->ns_mgr,
+                                               r_storage->s);
   }
   FUNC_END();
   return ret;

--- a/src/storage-rbox/rbox-storage.h
+++ b/src/storage-rbox/rbox-storage.h
@@ -65,7 +65,6 @@ struct rbox_mailbox {
   uint32_t ext_id;
 
   guid_128_t mailbox_guid;
-  uint32_t corrupted_rebuild_count;
 
   ARRAY(struct expunged_item *) moved_items;
 };

--- a/src/storage-rbox/rbox-storage.hpp
+++ b/src/storage-rbox/rbox-storage.hpp
@@ -40,12 +40,14 @@ struct rbox_storage {
   librmb::RadosMetadataStorage *ms;
   librmb::RadosStorage *alt;
   librmb::RadosSaveLog *save_log;
+
+  uint32_t corrupted_rebuild_count;
+  bool corrupted;
 };
 
 #endif
 
 struct index_rebuild_context;
-extern void rbox_sync_update_header(struct index_rebuild_context *ctx);
 extern struct mail_vfuncs rbox_mail_vfuncs;
 extern uint32_t rbox_get_uidvalidity_next(struct mailbox_list *list);
 extern struct mail_save_context *rbox_save_alloc(struct mailbox_transaction_context *_t);

--- a/src/storage-rbox/rbox-storage.hpp
+++ b/src/storage-rbox/rbox-storage.hpp
@@ -74,17 +74,5 @@ extern int rbox_mailbox_create_indexes(struct mailbox *box, const struct mailbox
                                        struct mail_index_transaction *trans);
 extern int check_users_mailbox_delete_ns_object(struct mail_user *user, librmb::RadosDovecotCephCfg *config,
                                                 librmb::RadosNamespaceManager *ns_mgr, librmb::RadosStorage *storage);
-/*
-struct mail_save_context *rbox_save_alloc(struct mailbox_transaction_context *_t);
-int rbox_save_begin(struct mail_save_context *ctx, struct istream *input);
-int rbox_save_continue(struct mail_save_context *ctx);
-int rbox_save_finish(struct mail_save_context *ctx);
-void rbox_save_cancel(struct mail_save_context *ctx);
-
-int rbox_transaction_save_commit_pre(struct mail_save_context *ctx);
-void rbox_transaction_save_commit_post(struct mail_save_context *ctx,
-                                       struct mail_index_transaction_commit_result *result);
-void rbox_transaction_save_rollback(struct mail_save_context *ctx);
-*/
 
 #endif  // SRC_STORAGE_RBOX_RBOX_STORAGE_HPP_

--- a/src/storage-rbox/rbox-sync-rebuild.cpp
+++ b/src/storage-rbox/rbox-sync-rebuild.cpp
@@ -1,3 +1,4 @@
+
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 /*
@@ -21,13 +22,13 @@ extern "C" {
 #include "rbox-storage.hpp"
 #include "rbox-mail.h"
 #include "encoding.h"
-#include "rados-mail-object.h"
+#include "../librmb/rados-mail.h"
 #include "rados-util.h"
 
-using librmb::RadosMailObject;
+using librmb::RadosMail;
 using librmb::rbox_metadata_key;
 
-int rbox_sync_add_object(struct index_rebuild_context *ctx, const std::string &oi, librmb::RadosMailObject *mail_obj,
+int rbox_sync_add_object(struct index_rebuild_context *ctx, const std::string &oi, librmb::RadosMail *mail_obj,
                          bool alt_storage, uint32_t next_uid) {
   FUNC_START();
   struct rbox_mailbox *rbox = (struct rbox_mailbox *)ctx->box;
@@ -104,7 +105,7 @@ int rbox_sync_rebuild_entry(struct index_rebuild_context *ctx, librados::NObject
   int ret = 0;
   while (iter != librados::NObjectIterator::__EndObjectIterator) {
     std::map<std::string, ceph::bufferlist> attrset;
-    librmb::RadosMailObject mail_object;
+    librmb::RadosMail mail_object;
     mail_object.set_oid((*iter).get_oid());
     int retx;
     if (rebuild_ctx->alt_storage) {

--- a/src/storage-rbox/rbox-sync-rebuild.cpp
+++ b/src/storage-rbox/rbox-sync-rebuild.cpp
@@ -31,8 +31,10 @@ int rbox_sync_add_object(struct index_rebuild_context *ctx, const std::string &o
                          bool alt_storage, uint32_t next_uid) {
   FUNC_START();
   struct rbox_mailbox *rbox_mailbox = (struct rbox_mailbox *)ctx->box;
-  std::string xattr_mail_uid = mail_obj->get_metadata(rbox_metadata_key::RBOX_METADATA_MAIL_UID);
-  std::string xattr_guid = mail_obj->get_metadata(rbox_metadata_key::RBOX_METADATA_GUID);
+  std::string xattr_mail_uid;
+  mail_obj->get_metadata(rbox_metadata_key::RBOX_METADATA_MAIL_UID, &xattr_mail_uid);
+  std::string xattr_guid;
+  mail_obj->get_metadata(rbox_metadata_key::RBOX_METADATA_GUID, &xattr_guid);
   struct mail_storage *storage = ctx->box->storage;
   struct rbox_storage *r_storage = (struct rbox_storage *)storage;
   uint32_t seq;
@@ -219,6 +221,7 @@ int rbox_sync_index_rebuild_objects(struct index_rebuild_context *ctx) {
   pool = pool_alloconly_create("rbox rebuild pool", 256);
 
   rebuild_ctx = p_new(pool, struct rbox_sync_rebuild_ctx, 1);
+  i_zero(rebuild_ctx);
   rebuild_ctx->alt_storage = false;
   rebuild_ctx->next_uid = INT_MAX;
 

--- a/src/storage-rbox/rbox-sync-rebuild.h
+++ b/src/storage-rbox/rbox-sync-rebuild.h
@@ -25,6 +25,7 @@ struct rbox_sync_rebuild_ctx {
   bool alt_storage;
   uint32_t next_uid;
 };
+extern void rbox_sync_update_header(struct index_rebuild_context *ctx);
 
 extern int rbox_sync_add_object(struct index_rebuild_context *ctx, const std::string &oi,
                                 librmb::RadosMailObject *mail_obj, bool alt_storage, uint32_t next_uid);
@@ -39,4 +40,5 @@ extern int rbox_sync_rebuild_entry(struct index_rebuild_context *ctx, librados::
 extern int rbox_sync_index_rebuild(struct rbox_mailbox *mbox, bool force);
 extern int search_objects(struct index_rebuild_context *ctx, struct rbox_sync_rebuild_ctx *rebuild_ctx);
 extern int rbox_storage_rebuild_in_context(struct rbox_storage *storage, bool force);
+extern int repair_namespace(struct mail_namespace *ns, bool force);
 #endif  // SRC_STORAGE_RBOX_RBOX_SYNC_REBUILD_H_

--- a/src/storage-rbox/rbox-sync-rebuild.h
+++ b/src/storage-rbox/rbox-sync-rebuild.h
@@ -37,8 +37,8 @@ extern void rbox_sync_set_uidvalidity(struct index_rebuild_context *ctx);
 extern int rbox_sync_index_rebuild_objects(struct index_rebuild_context *ctx);
 extern int rbox_sync_rebuild_entry(struct index_rebuild_context *ctx, librados::NObjectIterator &iter,
                                    struct rbox_sync_rebuild_ctx *rebuild_ctx);
-extern int rbox_sync_index_rebuild(struct rbox_mailbox *mbox, bool force);
+extern int rbox_sync_index_rebuild(struct rbox_mailbox *rbox, bool force);
 extern int search_objects(struct index_rebuild_context *ctx, struct rbox_sync_rebuild_ctx *rebuild_ctx);
-extern int rbox_storage_rebuild_in_context(struct rbox_storage *storage, bool force);
+extern int rbox_storage_rebuild_in_context(struct rbox_storage *r_storage, bool force);
 extern int repair_namespace(struct mail_namespace *ns, bool force);
 #endif  // SRC_STORAGE_RBOX_RBOX_SYNC_REBUILD_H_

--- a/src/storage-rbox/rbox-sync-rebuild.h
+++ b/src/storage-rbox/rbox-sync-rebuild.h
@@ -15,7 +15,8 @@
 #include <map>
 #include <string>
 #include <rados/librados.hpp>
-#include "rados-mail-object.h"
+
+#include "../librmb/rados-mail.h"
 
 extern "C" {
 #include "index-rebuild.h"
@@ -28,7 +29,7 @@ struct rbox_sync_rebuild_ctx {
 extern void rbox_sync_update_header(struct index_rebuild_context *ctx);
 
 extern int rbox_sync_add_object(struct index_rebuild_context *ctx, const std::string &oi,
-                                librmb::RadosMailObject *mail_obj, bool alt_storage, uint32_t next_uid);
+                                librmb::RadosMail *mail_obj, bool alt_storage, uint32_t next_uid);
 
 extern int rbox_sync_index_rebuild(struct index_rebuild_context *ctx, librados::NObjectIterator &iter,
                                    struct rbox_sync_rebuild_ctx *rebuild_ctx);

--- a/src/storage-rbox/rbox-sync.cpp
+++ b/src/storage-rbox/rbox-sync.cpp
@@ -184,7 +184,7 @@ static int update_flags(struct rbox_sync_context *ctx, uint32_t seq1, uint32_t s
     if (rbox_get_oid_from_index(ctx->sync_view, seq1, ((struct rbox_mailbox *)box)->ext_id, &index_oid) >= 0) {
       const char *oid = guid_128_to_string(index_oid);
 
-      librmb::RadosMailObject mail_object;
+      librmb::RadosMail mail_object;
       mail_object.set_oid(oid);
       r_storage->ms->get_storage()->load_metadata(&mail_object);
       std::string flags_metadata;

--- a/src/storage-rbox/rbox-sync.h
+++ b/src/storage-rbox/rbox-sync.h
@@ -23,7 +23,7 @@ struct expunged_item {
 };
 
 struct rbox_sync_context {
-  struct rbox_mailbox *mbox;
+  struct rbox_mailbox *rbox;
   struct mail_index_sync_ctx *index_sync_ctx;
   struct mail_index_view *sync_view;
   struct mail_index_transaction *trans;
@@ -39,9 +39,9 @@ struct expunge_callback_data {
   struct expunged_item *item;
 };
 
-int rbox_sync(struct rbox_mailbox *mbox, enum rbox_sync_flags flags);
+int rbox_sync(struct rbox_mailbox *rbox, enum rbox_sync_flags flags);
 
-int rbox_sync_begin(struct rbox_mailbox *mbox, struct rbox_sync_context **ctx_r, enum rbox_sync_flags flags);
+int rbox_sync_begin(struct rbox_mailbox *rbox, struct rbox_sync_context **ctx_r, enum rbox_sync_flags flags);
 int rbox_sync_finish(struct rbox_sync_context **ctx, bool success);
 
 #endif  // SRC_STORAGE_RBOX_RBOX_SYNC_H_

--- a/src/tests/.gitignore
+++ b/src/tests/.gitignore
@@ -21,3 +21,4 @@
 /it_test_sync_rbox_alt
 /it_test_sync_rbox_duplicate_uid
 /it_test_doveadm_rmb
+/it_test_backup

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -154,12 +154,15 @@ it_test_sync_rbox_duplicate_uid_CPPFLAGS = $(AM_CPPFLAGS) $(LIBDOVECOT_INCLUDE)
 it_test_sync_rbox_duplicate_uid_LDADD = $(storage_shlibs) $(gtest_shlibs) 
 
 
-
 TESTS += it_test_doveadm_rmb
 it_test_doveadm_rmb_SOURCES = doveadm-rmb/it_test_doveadm_rmb.cpp doveadm-rmb/TestCase.cpp doveadm-rmb/TestCase.h test-utils/it_utils.cpp test-utils/it_utils.h
 it_test_doveadm_rmb_CPPFLAGS = $(AM_CPPFLAGS) $(LIBDOVECOT_INCLUDE)  
 it_test_doveadm_rmb_LDADD = $(storage_shlibs) $(gtest_shlibs) $(doveadm_rmb_shlibs) 
 
+TESTS += it_test_backup
+it_test_backup_SOURCES = backup/it_test_backup_rbox.cpp backup/TestCase.cpp backup/TestCase.h test-utils/it_utils.cpp test-utils/it_utils.h
+it_test_backup_CPPFLAGS = $(AM_CPPFLAGS) $(LIBDOVECOT_INCLUDE)  
+it_test_backup_LDADD = $(storage_shlibs) $(gtest_shlibs) $(doveadm_rmb_shlibs) 
 
 endif
 

--- a/src/tests/backup/TestCase.cpp
+++ b/src/tests/backup/TestCase.cpp
@@ -1,0 +1,272 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Copyright (c) 2017-2018 Tallence AG and the authors
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#include "src/tests/backup/TestCase.h"
+
+#include <errno.h>
+#define typeof(x) __typeof__(x)
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"           // turn off warnings for Dovecot :-(
+#pragma GCC diagnostic ignored "-Wundef"            // turn off warnings for Dovecot :-(
+#pragma GCC diagnostic ignored "-Wredundant-decls"  // turn off warnings for Dovecot :-(
+#ifndef __cplusplus
+#pragma GCC diagnostic ignored "-Wdeclaration-after-statement"  // turn off warnings for Dovecot :-(
+#endif
+
+extern "C" {
+#include "lib.h"
+#include "ioloop.h"
+#include "master-service.h"
+#include "master-service-settings.h"
+#include "randgen.h"
+#include "hostpid.h"
+#include "mail-storage.h"
+#include "mail-storage-service.h"
+#include "settings-parser.h"
+#include "unlink-directory.h"
+
+#include "libstorage-rbox-plugin.h"
+#include "array.h"
+#include "array-decl.h"
+}
+
+#pragma GCC diagnostic pop
+
+#if DOVECOT_PREREQ(2, 3)
+#else
+#define mail_storage_service_next(ctx, user, mail_user_r, error_r) mail_storage_service_next(ctx, user, mail_user_r)
+#define unlink_directory(dir, flags, error_r) unlink_directory(dir, flags)
+#endif
+
+#ifndef i_zero
+#define i_zero(p) memset(p, 0, sizeof(*(p)))
+#endif
+static const char *rbox_pool_name = "rbox_pool_name";
+
+static int set_user_env(struct mail_user *user, const char *val) {
+  const char *const *envs;
+  unsigned int count, i;
+  bool newly_created = false;
+
+  if (!array_is_created(&user->set->plugin_envs)) {
+    i_array_init(&user->set->plugin_envs, 2);
+    newly_created = true;
+  }
+
+  if (!newly_created) {
+    return 0;
+  }
+  array_append(&user->set->plugin_envs, &rbox_pool_name, 1);
+  array_append(&user->set->plugin_envs, &val, 1);
+  envs = array_get_modifiable(&user->set->plugin_envs, &count);
+
+  for (i = 0; i < count; i += 2) {
+    if (strcmp(envs[i], rbox_pool_name) == 0) {
+      i_debug("found %s", envs[i + 1]);
+      return 0;
+    }
+  }
+
+  return -1;
+}
+
+static std::string get_temp_pool_name(const std::string &prefix) {
+  char hostname[80];
+  char out[160];
+  memset(hostname, 0, sizeof(hostname));
+  memset(out, 0, sizeof(out));
+  gethostname(hostname, sizeof(hostname) - 1);
+  static int num = 1;
+  snprintf(out, sizeof(out), "%s-%d-%d", hostname, getpid(), num);
+  num++;
+  return prefix + out;
+}
+
+static std::string connect_cluster(rados_t *cluster) {
+  char *id = getenv("CEPH_CLIENT_ID");
+  if (id)
+    std::cerr << "Client id is: " << id << std::endl;
+
+  int ret;
+  ret = rados_create(cluster, NULL);
+  if (ret) {
+    std::ostringstream oss;
+    oss << "rados_create failed with error " << ret;
+    return oss.str();
+  }
+  ret = rados_conf_read_file(*cluster, NULL);
+  if (ret) {
+    rados_shutdown(*cluster);
+    std::ostringstream oss;
+    oss << "rados_conf_read_file failed with error " << ret;
+    return oss.str();
+  }
+  rados_conf_parse_env(*cluster, NULL);
+  rados_conf_set(*cluster, "client_mount_timeout", "300");
+  rados_conf_set(*cluster, "rados_mon_op_timeout", "300");
+  rados_conf_set(*cluster, "os_osd_op_timeout", "300");
+
+  ret = rados_connect(*cluster);
+  if (ret) {
+    rados_shutdown(*cluster);
+    std::ostringstream oss;
+    oss << "rados_connect failed with error " << ret;
+    return oss.str();
+  }
+  return "";
+}
+
+static std::string create_one_pool(const std::string &pool_name, rados_t *cluster, uint32_t pg_num = 0) {
+  std::string err_str = connect_cluster(cluster);
+
+  if (err_str.length())
+    return err_str;
+
+  int ret = rados_pool_create(*cluster, pool_name.c_str());
+  if (ret) {
+    rados_shutdown(*cluster);
+    std::ostringstream oss;
+
+    oss << "create_one_pool(" << pool_name << ") failed with error " << ret;
+    return oss.str();
+  }
+
+  return "";
+}
+
+static int destroy_one_pool(const std::string &pool_name, rados_t *cluster) {
+  int ret = rados_pool_delete(*cluster, pool_name.c_str());
+  if (ret) {
+    rados_shutdown(*cluster);
+    return ret;
+  }
+  rados_shutdown(*cluster);
+  return 0;
+}
+
+static struct mail_storage_service_ctx *mail_storage_service = nullptr;
+struct mail_user *BackupTest::s_test_mail_user = nullptr;
+static struct mail_storage_service_user *test_service_user = nullptr;
+static const char *mail_home;
+
+rados_t BackupTest::s_cluster = nullptr;
+rados_ioctx_t BackupTest::s_ioctx = nullptr;
+
+std::string BackupTest::pool_name;  // NOLINT
+std::string BackupTest::uri;        // NOLINT
+struct ioloop *BackupTest::s_test_ioloop = nullptr;
+pool_t BackupTest::s_test_pool = nullptr;
+
+static const char *username = "user-rbox-test@localhost";
+
+void BackupTest::SetUpTestCase() {
+  // prepare Ceph
+  pool_name = get_temp_pool_name("test-storage-rbox-");
+  create_one_pool(pool_name, &s_cluster);
+  rados_ioctx_create(s_cluster, pool_name.c_str(), &s_ioctx);
+
+  // prepare Dovecot
+  uri = "oid=metadata:pool=" + pool_name;
+
+  const char *error;
+  char path_buf[4096];
+
+  char arg0[] = "storage-rbox-test";
+  char *argv[] = {&arg0[0], NULL};
+  auto a = &argv;
+  int argc = static_cast<int>((sizeof(argv) / sizeof(argv[0])) - 1);
+
+  master_service = master_service_init(
+      "storage-rbox-test",
+      (master_service_flags)(MASTER_SERVICE_FLAG_STANDALONE | MASTER_SERVICE_FLAG_NO_CONFIG_SETTINGS |
+                             MASTER_SERVICE_FLAG_NO_SSL_INIT),
+      &argc, reinterpret_cast<char ***>(&a), "");
+  ASSERT_NE(master_service, nullptr);
+
+  random_init();
+
+  master_service_init_log(master_service, t_strdup_printf("storage_rbox(%s): ", my_pid));
+  master_service_init_finish(master_service);
+
+  s_test_pool = pool_alloconly_create(MEMPOOL_GROWING "storage-rbox-test-pool", 1024);
+  s_test_ioloop = io_loop_create();
+
+  ASSERT_NE(getcwd(path_buf, sizeof(path_buf)), nullptr);
+
+  // mail_home = p_strdup_printf(s_test_pool, "%s/user-%s/", path_buf, pool_name.c_str());
+  mail_home = p_strdup_printf(s_test_pool, "%s/%s/", path_buf, username);
+
+  const char *const userdb_fields[] = {t_strdup_printf("mail=rbox:%s", mail_home),
+                                       t_strdup_printf("home=%s", mail_home), NULL};
+
+  struct mail_storage_service_input input;
+  i_zero(&input);
+  input.userdb_fields = userdb_fields;
+  input.username = username;
+  input.no_userdb_lookup = TRUE;
+#if DOVECOT_PREREQ(2, 3)
+  input.debug = TRUE;
+#endif
+
+  mail_storage_service = mail_storage_service_init(
+      master_service, NULL,
+      (mail_storage_service_flags)(MAIL_STORAGE_SERVICE_FLAG_NO_RESTRICT_ACCESS |
+                                   MAIL_STORAGE_SERVICE_FLAG_NO_LOG_INIT | MAIL_STORAGE_SERVICE_FLAG_NO_PLUGINS));
+  ASSERT_NE(mail_storage_service, nullptr);
+
+  storage_rbox_plugin_init(0);
+
+  ASSERT_GE(mail_storage_service_lookup(mail_storage_service, &input, &test_service_user, &error), 0);
+
+  struct setting_parser_context *set_parser = mail_storage_service_user_get_settings_parser(test_service_user);
+  ASSERT_NE(set_parser, nullptr);
+
+  ASSERT_GE(
+      settings_parse_line(set_parser, t_strdup_printf("mail_attribute_dict=file:%s/dovecot-attributes", mail_home)), 0);
+
+  ASSERT_GE(mail_storage_service_next(mail_storage_service, test_service_user, &s_test_mail_user, &error), 0);
+
+  set_user_env(s_test_mail_user, BackupTest::pool_name.c_str());
+}
+
+void BackupTest::TearDownTestCase() {
+  if (array_is_created(&s_test_mail_user->set->plugin_envs)) {
+    if (array_count(&s_test_mail_user->set->plugin_envs) > 0) {
+      array_delete(&s_test_mail_user->set->plugin_envs, array_count(&s_test_mail_user->set->plugin_envs) - 1, 1);
+    }
+    array_free(&s_test_mail_user->set->plugin_envs);
+  }
+  mail_user_unref(&s_test_mail_user);
+#if DOVECOT_PREREQ(2, 3)
+  mail_storage_service_user_unref(&test_service_user);
+
+  const char *error;
+#else
+  mail_storage_service_user_free(&test_service_user);
+#endif
+
+  storage_rbox_plugin_deinit();
+
+  mail_storage_service_deinit(&mail_storage_service);
+  EXPECT_GE(unlink_directory(mail_home, UNLINK_DIRECTORY_FLAG_RMDIR, &error), 0);
+
+  io_loop_destroy(&s_test_ioloop);
+  pool_unref(&s_test_pool);
+  destroy_one_pool(pool_name, &s_cluster);
+  rados_ioctx_destroy(s_ioctx);
+
+  master_service_deinit(&master_service);
+}
+
+void BackupTest::SetUp() {}
+
+void BackupTest::TearDown() {}

--- a/src/tests/backup/TestCase.h
+++ b/src/tests/backup/TestCase.h
@@ -1,0 +1,58 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Copyright (c) 2017-2018 Tallence AG and the authors
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#ifndef SRC_TESTS_STORAGE_RBOX_TESTCASE_H_
+#define SRC_TESTS_STORAGE_RBOX_TESTCASE_H_
+
+#include <string>
+
+#include "rados/librados.h"
+#include "rados/librados.hpp"
+#include "gtest/gtest.h"
+
+typedef struct pool *pool_t;
+
+/**
+ * These test cases create a temporary pool that lives as long as the
+ * test case.  Each test within a test case gets a new ioctx and striper
+ * set to a unique namespace within the pool.
+ *
+ * Since pool creation and deletion is slow, this allows many tests to
+ * run faster.
+ */
+class BackupTest : public ::testing::Test {
+ public:
+  BackupTest() {}
+  ~BackupTest() override {}
+
+  static pool_t get_test_pool() { return s_test_pool; }
+
+ protected:
+  static void SetUpTestCase();
+  static void TearDownTestCase();
+  static int init_test_mail_user(void);
+
+  static rados_t s_cluster;
+  static rados_ioctx_t s_ioctx;
+
+  static std::string pool_name;
+  static std::string uri;
+  static struct ioloop *s_test_ioloop;
+  static pool_t s_test_pool;
+
+  static struct mail_user *s_test_mail_user;
+
+  void SetUp() override;
+  void TearDown() override;
+
+};
+
+#endif  // SRC_TESTS_STORAGE_RBOX_TESTCASE_H_

--- a/src/tests/backup/it_test_backup_rbox.cpp
+++ b/src/tests/backup/it_test_backup_rbox.cpp
@@ -31,7 +31,6 @@ extern "C" {
 #include "ioloop.h"
 #include "istream.h"
 #include "mail-search-build.h"
-
 #include "libdict-rados-plugin.h"
 #include "mail-search-parser-private.h"
 #include "mail-search.h"
@@ -44,17 +43,18 @@ extern "C" {
 using ::testing::AtLeast;
 using ::testing::Return;
 
-TEST_F(StorageTest, init) {}
+TEST_F(BackupTest, init) {}
 
-TEST_F(StorageTest, mailbox_open_inbox) {
+TEST_F(BackupTest, mailbox_open_inbox) {
   struct mail_namespace *ns = mail_namespace_find_inbox(s_test_mail_user->namespaces);
   struct mailbox *box = mailbox_alloc(ns->list, "INBOX", MAILBOX_FLAG_READONLY);
   ASSERT_GE(mailbox_open(box), 0);
   mailbox_free(&box);
 }
 
-TEST_F(StorageTest, mail_copy_mail_in_inbox) {
+TEST_F(BackupTest, mail_copy_mail_in_inbox) {
   struct mailbox_transaction_context *desttrans;
+  struct mail_save_context *save_ctx;
   struct mail *mail;
   struct mail_search_context *search_ctx;
   struct mail_search_args *search_args;
@@ -70,8 +70,44 @@ TEST_F(StorageTest, mail_copy_mail_in_inbox) {
 
   const char *mailbox = "INBOX";
 
-  // testdata
-  testutils::ItUtils::add_mail(message, mailbox, StorageTest::s_test_mail_user->namespaces);
+  // create some testmails and delete the one with uid = 1
+
+  testutils::ItUtils::add_mail(message, mailbox, BackupTest::s_test_mail_user->namespaces);
+  testutils::ItUtils::add_mail(message, mailbox, BackupTest::s_test_mail_user->namespaces);
+  testutils::ItUtils::add_mail(message, mailbox, BackupTest::s_test_mail_user->namespaces);
+  testutils::ItUtils::add_mail(message, mailbox, BackupTest::s_test_mail_user->namespaces);
+
+  // sleep(10);
+  rados_list_ctx_t listh;
+  std::cout << "POOL: " << BackupTest::pool_name << std::endl;
+  rados_ioctx_set_namespace(BackupTest::s_ioctx, "user-rbox-test@localhost_u");
+  rados_nobjects_list_open(BackupTest::s_ioctx, &listh);
+
+  rados_list_ctx_t ctx;
+  std::string to_delete;
+  ASSERT_EQ(0, rados_nobjects_list_open(BackupTest::s_ioctx, &ctx));
+  const char *entry;
+  int foundit = 0;
+  while (rados_nobjects_list_next(ctx, &entry, NULL, NULL) != -ENOENT) {
+    foundit++;
+    //ASSERT_EQ(std::string(entry), "foo");
+    char xattr_res[100];
+
+    ASSERT_EQ(rados_getxattr(BackupTest::s_ioctx, entry, "U", xattr_res, 1), 1);
+    std::string v(&xattr_res[0], 1);
+    if (v.compare("1") == 0) {
+      to_delete = entry;
+    }
+    std::cout << std::string(entry) << std::endl;
+  }
+  ASSERT_TRUE(foundit == 4);
+  ASSERT_TRUE(!to_delete.empty());
+  rados_nobjects_list_close(ctx);
+
+  // delete UID=1
+  ASSERT_EQ(rados_remove(BackupTest::s_ioctx, to_delete.c_str()), 0);
+
+  // trigger the backup command!
 
   search_args = mail_search_build_init();
   sarg = mail_search_build_add(search_args, SEARCH_ALL);
@@ -86,6 +122,7 @@ TEST_F(StorageTest, mail_copy_mail_in_inbox) {
     i_error("Opening mailbox %s failed: %s", mailbox, mailbox_get_last_internal_error(box, NULL));
     FAIL() << " Forcing a resync on mailbox INBOX Failed";
   }
+
 #ifdef DOVECOT_CEPH_PLUGIN_HAVE_MAIL_STORAGE_TRANSACTION_OLD_SIGNATURE
   desttrans = mailbox_transaction_begin(box, MAILBOX_TRANSACTION_FLAG_EXTERNAL);
 #else
@@ -96,74 +133,35 @@ TEST_F(StorageTest, mail_copy_mail_in_inbox) {
 
   search_ctx = mailbox_search_init(desttrans, search_args, NULL, static_cast<mail_fetch_field>(0), NULL);
   mail_search_args_unref(&search_args);
-
   struct message_size hdr_size, body_size;
   struct istream *input = NULL;
   while (mailbox_search_next(search_ctx, &mail)) {
-    int ret2 = mail_get_stream(mail, &hdr_size, &body_size, &input);
-    EXPECT_EQ(ret2, 0);
-    EXPECT_NE(input, nullptr);
-    EXPECT_NE(body_size.physical_size, (uoff_t)0);
-    EXPECT_NE(hdr_size.physical_size, (uoff_t)0);
-
-    size_t size = -1;
-    int ret_size = i_stream_get_size(input, true, &size);
-    EXPECT_EQ(ret_size, 1);
-    uoff_t phy_size;
-    index_mail_get_physical_size(mail, &phy_size);
-
-    std::string msg3(
-        "From: user@domain.org\nDate: Sat, 24 Mar 2017 23:00:00 +0200\nMime-Version: 1.0\nContent-Type: "
-        "text/plain; charset=us-ascii\n\nbody\n");
-
-    EXPECT_EQ(phy_size, msg3.length());  // i_stream ads a \r before every \n
-
-    // read the input stream and evaluate content.
-    struct const_iovec iov;
-    const unsigned char *data = NULL;
-    ssize_t ret = 0;
-    std::string buff;
-    do {
-      (void)i_stream_read_data(input, &data, &iov.iov_len, 0);
-      if (iov.iov_len == 0) {
-
-    if (input->stream_errno != 0)
-      FAIL() << "stream errno";
-    break;
-      }
-      const char *data_t = reinterpret_cast<const char *>(data);
-      std::string tmp(data_t, phy_size);
-      buff += tmp;
-    } while ((size_t)ret == iov.iov_len);
-
-    //    i_debug("data: %s", buff.c_str());
-    std::string msg(
-        "From: user@domain.org\nDate: Sat, 24 Mar 2017 23:00:00 +0200\nMime-Version: 1.0\nContent-Type: "
-        "text/plain; charset=us-ascii\n\nbody\n");
-
-    // validate !
-    EXPECT_EQ(buff, msg);
-
-    break;
+    if (mail->uid == 1) {
+      int ret = mail_get_stream(mail, &hdr_size, &body_size, &input);
+      EXPECT_EQ(ret, -1);
+      enum mail_error error;
+      const char *errstr;
+      errstr = mailbox_get_last_error(mail->box, &error);
+      EXPECT_EQ(error, MAIL_ERROR_EXPUNGED);
+    }
   }
 
   if (mailbox_search_deinit(&search_ctx) < 0) {
     FAIL() << "search deinit failed";
   }
-
+  i_debug("after search");
   if (mailbox_transaction_commit(&desttrans) < 0) {
     FAIL() << "tnx commit failed";
   }
-
+  i_debug("after commit");
   if (mailbox_sync(box, static_cast<mailbox_sync_flags>(0)) < 0) {
     FAIL() << "sync failed";
   }
-
-  ASSERT_EQ(1, (int)box->index->map->hdr.messages_count);
+  i_debug("after sync");
   mailbox_free(&box);
 }
 
-TEST_F(StorageTest, deinit) {}
+TEST_F(BackupTest, deinit) {}
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleMock(&argc, argv);

--- a/src/tests/backup/it_test_backup_rbox.cpp
+++ b/src/tests/backup/it_test_backup_rbox.cpp
@@ -54,7 +54,6 @@ TEST_F(BackupTest, mailbox_open_inbox) {
 
 TEST_F(BackupTest, mail_copy_mail_in_inbox) {
   struct mailbox_transaction_context *desttrans;
-  struct mail_save_context *save_ctx;
   struct mail *mail;
   struct mail_search_context *search_ctx;
   struct mail_search_args *search_args;
@@ -90,7 +89,7 @@ TEST_F(BackupTest, mail_copy_mail_in_inbox) {
   int foundit = 0;
   while (rados_nobjects_list_next(ctx, &entry, NULL, NULL) != -ENOENT) {
     foundit++;
-    //ASSERT_EQ(std::string(entry), "foo");
+    // ASSERT_EQ(std::string(entry), "foo");
     char xattr_res[100];
 
     ASSERT_EQ(rados_getxattr(BackupTest::s_ioctx, entry, "U", xattr_res, 1), 1);
@@ -100,7 +99,7 @@ TEST_F(BackupTest, mail_copy_mail_in_inbox) {
     }
     std::cout << std::string(entry) << std::endl;
   }
-  ASSERT_TRUE(foundit == 4);
+  ASSERT_EQ(foundit, 4);
   ASSERT_TRUE(!to_delete.empty());
   rados_nobjects_list_close(ctx);
 

--- a/src/tests/backup/it_test_backup_rbox.cpp
+++ b/src/tests/backup/it_test_backup_rbox.cpp
@@ -78,10 +78,10 @@ TEST_F(BackupTest, mail_copy_mail_in_inbox) {
   testutils::ItUtils::add_mail(message, mailbox, BackupTest::s_test_mail_user->namespaces);
 
   // sleep(10);
-  rados_list_ctx_t listh;
+  // rados_list_ctx_t listh;
   std::cout << "POOL: " << BackupTest::pool_name << std::endl;
   rados_ioctx_set_namespace(BackupTest::s_ioctx, "user-rbox-test@localhost_u");
-  rados_nobjects_list_open(BackupTest::s_ioctx, &listh);
+  // rados_nobjects_list_open(BackupTest::s_ioctx, &listh);
 
   rados_list_ctx_t ctx;
   std::string to_delete;

--- a/src/tests/librmb/it_test_librmb.cpp
+++ b/src/tests/librmb/it_test_librmb.cpp
@@ -38,7 +38,7 @@ TEST(librmb, mock_test) {
 
 TEST(librmb, split_write_operation) {
   uint64_t max_size = 3;
-  librmb::RadosMailObject obj;
+  librmb::RadosMail obj;
   obj.get_mail_buffer()->append("abcdefghijklmn");
   size_t buffer_length = obj.get_mail_buffer()->length();
   obj.set_mail_size(buffer_length);
@@ -80,7 +80,7 @@ TEST(librmb, split_write_operation) {
 }
 
 TEST(librmb1, split_write_operation_1) {
-  librmb::RadosMailObject obj;
+  librmb::RadosMail obj;
   obj.get_mail_buffer()->append("HALLO_WELT_");
   size_t buffer_length = obj.get_mail_buffer()->length();
   obj.set_mail_size(buffer_length);
@@ -152,7 +152,7 @@ TEST(librmb1, convert_types) {
 }
 
 TEST(librmb1, read_mail) {
-  librmb::RadosMailObject obj;
+  librmb::RadosMail obj;
   obj.get_mail_buffer()->append("abcdefghijklmn");
   size_t buffer_length = obj.get_mail_buffer()->length();
   obj.set_mail_size(buffer_length);
@@ -208,7 +208,7 @@ TEST(librmb1, read_mail) {
 
 TEST(librmb, load_metadata) {
   uint64_t max_size = 3;
-  librmb::RadosMailObject obj;
+  librmb::RadosMail obj;
   obj.get_mail_buffer()->append("abcdefghijklmn");
   size_t buffer_length = obj.get_mail_buffer()->length();
   obj.set_mail_size(buffer_length);
@@ -267,7 +267,7 @@ TEST(librmb, load_metadata) {
 
 TEST(librmb, AttributeVersions) {
   uint64_t max_size = 3;
-  librmb::RadosMailObject obj;
+  librmb::RadosMail obj;
   obj.get_mail_buffer()->append("abcdefghijklmn");
   size_t buffer_length = obj.get_mail_buffer()->length();
   obj.set_mail_size(buffer_length);
@@ -349,7 +349,7 @@ TEST(librmb, json_ima) {
   // cfg.update_updatable_attributes("");
   librmb::RadosMetadataStorageIma ms(&storage.get_io_ctx(), &cfg);
 
-  librmb::RadosMailObject obj;
+  librmb::RadosMail obj;
   obj.get_mail_buffer()->append("abcdefghijklmn");
   size_t buffer_length = obj.get_mail_buffer()->length();
   obj.set_mail_size(buffer_length);
@@ -418,7 +418,7 @@ TEST(librmb, json_ima_2) {
   cfg.update_updatable_attributes("F");
   librmb::RadosMetadataStorageIma ms(&storage.get_io_ctx(), &cfg);
 
-  librmb::RadosMailObject obj;
+  librmb::RadosMail obj;
   obj.get_mail_buffer()->append("abcdefghijklmn");
   size_t buffer_length = obj.get_mail_buffer()->length();
   obj.set_mail_size(buffer_length);
@@ -487,7 +487,7 @@ TEST(librmb, json_ima_3) {
   cfg.update_updatable_attributes("FK");
   librmb::RadosMetadataStorageIma ms(&storage.get_io_ctx(), &cfg);
 
-  librmb::RadosMailObject obj;
+  librmb::RadosMail obj;
   obj.get_mail_buffer()->append("abcdefghijklmn");
   size_t buffer_length = obj.get_mail_buffer()->length();
   obj.set_mail_size(buffer_length);
@@ -565,7 +565,7 @@ TEST(librmb, test_default_metadata_load_attributes) {
   cfg.update_updatable_attributes("FK");
   librmb::RadosMetadataStorageDefault ms(&storage.get_io_ctx());
 
-  librmb::RadosMailObject obj;
+  librmb::RadosMail obj;
   obj.get_mail_buffer()->append("abcdefghijklmn");
   size_t buffer_length = obj.get_mail_buffer()->length();
   obj.set_mail_size(buffer_length);
@@ -597,7 +597,7 @@ TEST(librmb, test_default_metadata_load_attributes) {
    // wait for op to finish.
    storage.wait_for_write_operations_complete(obj.get_completion_op_map());
 
-   librmb::RadosMailObject obj2;
+   librmb::RadosMail obj2;
    obj2.set_oid("test_ima");
 
    int a = ms.load_metadata(&obj2);
@@ -626,7 +626,7 @@ TEST(librmb, test_default_metadata_load_attributes_obj_no_longer_exist) {
   cfg.update_updatable_attributes("FK");
   librmb::RadosMetadataStorageDefault ms(&storage.get_io_ctx());
 
-  librmb::RadosMailObject obj2;
+  librmb::RadosMail obj2;
   obj2.set_oid("test_ima1");
 
   int a = ms.load_metadata(&obj2);
@@ -654,7 +654,7 @@ TEST(librmb, test_default_metadata_load_attributes_obj_no_longer_exist_ima) {
   cfg.update_updatable_attributes("FK");
   librmb::RadosMetadataStorageIma ms(&storage.get_io_ctx(), &cfg);
 
-  librmb::RadosMailObject obj2;
+  librmb::RadosMail obj2;
   obj2.set_oid("test_ima1");
 
   int a = ms.load_metadata(&obj2);
@@ -679,7 +679,7 @@ TEST(librmb, increment_add_to_non_existing_key) {
 
   std::string key = "my-key";
 
-  librmb::RadosMailObject obj2;
+  librmb::RadosMail obj2;
   obj2.set_oid("myobject");
 
   ceph::bufferlist mail_buf;
@@ -719,7 +719,7 @@ TEST(librmb, increment_add_to_non_existing_object) {
 
   std::string key = "my-key";
 
-  librmb::RadosMailObject obj2;
+  librmb::RadosMail obj2;
   obj2.set_oid("myobject");
 
   long val = 10;  // value to add
@@ -759,7 +759,7 @@ TEST(librmb, increment_add_to_existing_key) {
 
   std::string key = "my-key";
 
-  librmb::RadosMailObject obj2;
+  librmb::RadosMail obj2;
   obj2.set_oid("myobject");
 
   ceph::bufferlist mail_buf;
@@ -802,7 +802,7 @@ TEST(librmb, increment_sub_from_existing_key) {
 
   std::string key = "my-key";
 
-  librmb::RadosMailObject obj2;
+  librmb::RadosMail obj2;
   obj2.set_oid("myobject");
 
   ceph::bufferlist mail_buf;
@@ -864,20 +864,20 @@ TEST(librmb, rmb_load_objects) {
   EXPECT_NE(nullptr, ms);
 
   storage.set_namespace(ns);
-  librmb::RadosMailObject obj2;
+  librmb::RadosMail obj2;
   obj2.set_oid("myobject");
 
   ceph::bufferlist mail_buf;
   storage.save_mail(obj2.get_oid(), mail_buf);
 
-  std::vector<librmb::RadosMailObject *> mail_objects;
+  std::vector<librmb::RadosMail *> mail_objects;
   std::string sort_string = "uid";
 
   EXPECT_EQ(0, rmb_commands.load_objects(ms, mail_objects, sort_string));
   EXPECT_EQ(1, mail_objects.size());
 
-  for (std::vector<librmb::RadosMailObject *>::iterator it = mail_objects.begin(); it != mail_objects.end(); ++it) {
-    librmb::RadosMailObject *obj = *it;
+  for (std::vector<librmb::RadosMail *>::iterator it = mail_objects.begin(); it != mail_objects.end(); ++it) {
+    librmb::RadosMail *obj = *it;
     delete obj;
   }
 
@@ -921,7 +921,7 @@ TEST(librmb, rmb_load_objects_valid_metadata) {
 
   storage.set_namespace(ns);
 
-  librmb::RadosMailObject obj2;
+  librmb::RadosMail obj2;
   obj2.set_oid("myobject_valid");
   obj2.get_mail_buffer()->append("hallo_welt");  // make sure obj is not empty.
   obj2.set_mail_size(obj2.get_mail_buffer()->length());
@@ -1008,12 +1008,12 @@ TEST(librmb, rmb_load_objects_valid_metadata) {
   ms->save_metadata(write_op, &obj2);
   // save complete mail.
   EXPECT_EQ(true, storage.save_mail(write_op, &obj2, true));
-  std::vector<librmb::RadosMailObject *> list;
+  std::vector<librmb::RadosMail *> list;
   list.push_back(&obj2);
 
   EXPECT_EQ(true, !storage.wait_for_rados_operations(list));
 
-  std::vector<librmb::RadosMailObject *> mail_objects;
+  std::vector<librmb::RadosMail *> mail_objects;
   std::string sort_string = "uid";
 
   EXPECT_EQ(0, rmb_commands.load_objects(ms, mail_objects, sort_string));
@@ -1022,8 +1022,8 @@ TEST(librmb, rmb_load_objects_valid_metadata) {
 
   storage.delete_mail(&obj2);
   storage.delete_mail(ceph_cfg.get_cfg_object_name());
-  for (std::vector<librmb::RadosMailObject *>::iterator it = mail_objects.begin(); it != mail_objects.end(); ++it) {
-    librmb::RadosMailObject *obj = *it;
+  for (std::vector<librmb::RadosMail *>::iterator it = mail_objects.begin(); it != mail_objects.end(); ++it) {
+    librmb::RadosMail *obj = *it;
     storage.delete_mail(obj);
     delete obj;
   }
@@ -1068,7 +1068,7 @@ TEST(librmb, rmb_load_objects_invalid_metadata) {
 
   storage.set_namespace(ns);
 
-  librmb::RadosMailObject obj2;
+  librmb::RadosMail obj2;
   obj2.set_oid("myobject_invalid");
   obj2.get_mail_buffer()->append("hallo_welt");  // make sure obj is not empty.
   obj2.set_mail_size(obj2.get_mail_buffer()->length());
@@ -1155,20 +1155,20 @@ TEST(librmb, rmb_load_objects_invalid_metadata) {
   ms->save_metadata(write_op, &obj2);
   // save complete mail.
   EXPECT_EQ(true, storage.save_mail(write_op, &obj2, true));
-  std::vector<librmb::RadosMailObject *> list;
+  std::vector<librmb::RadosMail *> list;
   list.push_back(&obj2);
 
   EXPECT_EQ(true, !storage.wait_for_rados_operations(list));
 
-  std::vector<librmb::RadosMailObject *> mail_objects;
+  std::vector<librmb::RadosMail *> mail_objects;
   std::string sort_string = "uid";
 
   EXPECT_EQ(0, rmb_commands.load_objects(ms, mail_objects, sort_string));
   // no mail
   EXPECT_EQ(1, mail_objects.size());
 
-  for (std::vector<librmb::RadosMailObject *>::iterator it = mail_objects.begin(); it != mail_objects.end(); ++it) {
-    librmb::RadosMailObject *obj = *it;
+  for (std::vector<librmb::RadosMail *>::iterator it = mail_objects.begin(); it != mail_objects.end(); ++it) {
+    librmb::RadosMail *obj = *it;
     delete obj;
   }
 

--- a/src/tests/mocks/mock_test.h
+++ b/src/tests/mocks/mock_test.h
@@ -23,7 +23,7 @@
 
 namespace librmbtest {
 using librmb::RadosStorage;
-using librmb::RadosMailObject;
+using librmb::RadosMail;
 using librmb::RadosMetadata;
 using librmb::RadosStorageMetadataModule;
 using librmb::RadosMetadataStorage;
@@ -40,10 +40,10 @@ class RadosStorageMock : public RadosStorage {
   MOCK_METHOD0(get_max_write_size_bytes, int());
 
   MOCK_METHOD3(split_buffer_and_exec_op,
-               int(RadosMailObject *current_object, librados::ObjectWriteOperation *write_op_xattr,
+               int(RadosMail *current_object, librados::ObjectWriteOperation *write_op_xattr,
                    const uint64_t &max_write));
 
-  MOCK_METHOD1(delete_mail, int(RadosMailObject *mail));
+  MOCK_METHOD1(delete_mail, int(RadosMail *mail));
   MOCK_METHOD1(delete_mail, int(const std::string &oid));
   MOCK_METHOD4(aio_operate, int(librados::IoCtx *io_ctx_, const std::string &oid, librados::AioCompletion *c,
                                 librados::ObjectWriteOperation *op));
@@ -54,7 +54,7 @@ class RadosStorageMock : public RadosStorage {
   MOCK_METHOD0(close_connection, void());
   MOCK_METHOD1(wait_for_write_operations_complete,
                bool(std::map<librados::AioCompletion *, librados::ObjectWriteOperation *> *completion_op_map));
-  MOCK_METHOD1(wait_for_rados_operations, bool(const std::vector<librmb::RadosMailObject *> &object_list));
+  MOCK_METHOD1(wait_for_rados_operations, bool(const std::vector<librmb::RadosMail *> &object_list));
 
   MOCK_METHOD2(read_mail, int(const std::string &oid, librados::bufferlist *buffer));
   MOCK_METHOD6(move, int(std::string &src_oid, const char *src_ns, std::string &dest_oid, const char *dest_ns,
@@ -63,21 +63,21 @@ class RadosStorageMock : public RadosStorage {
   MOCK_METHOD5(copy, int(std::string &src_oid, const char *src_ns, std::string &dest_oid, const char *dest_ns,
                          std::list<RadosMetadata> &to_update));
   MOCK_METHOD2(save_mail, int(const std::string &oid, librados::bufferlist &bufferlist));
-  MOCK_METHOD2(save_mail, bool(RadosMailObject *mail, bool &save_async));
-  MOCK_METHOD3(save_mail, bool(librados::ObjectWriteOperation *write_op, RadosMailObject *mail, bool save_async));
-  MOCK_METHOD0(alloc_mail_object, librmb::RadosMailObject *());
+  MOCK_METHOD2(save_mail, bool(RadosMail *mail, bool &save_async));
+  MOCK_METHOD3(save_mail, bool(librados::ObjectWriteOperation *write_op, RadosMail *mail, bool save_async));
+  MOCK_METHOD0(alloc_rados_mail, librmb::RadosMail *());
 
-  MOCK_METHOD1(free_mail_object, void(librmb::RadosMailObject *mail));
+  MOCK_METHOD1(free_rados_mail, void(librmb::RadosMail *mail));
 };
 
 class RadosStorageMetadataMock : public RadosStorageMetadataModule {
  public:
   MOCK_METHOD1(set_io_ctx, void(librados::IoCtx *io_ctx));
-  MOCK_METHOD1(load_metadata, int(RadosMailObject *mail));
-  MOCK_METHOD2(set_metadata, int(RadosMailObject *mail, RadosMetadata &xattr));
+  MOCK_METHOD1(load_metadata, int(RadosMail *mail));
+  MOCK_METHOD2(set_metadata, int(RadosMail *mail, RadosMetadata &xattr));
   MOCK_METHOD2(update_metadata, bool(const std::string &oid, std::list<RadosMetadata> &to_update));
   // MOCK_METHOD2(save_metadata, void(librados::ObjectWriteOperation *write_op, RadosMailObject *mail));
-  void save_metadata(librados::ObjectWriteOperation *write_op, RadosMailObject *mail) {
+  void save_metadata(librados::ObjectWriteOperation *write_op, RadosMail *mail) {
     // delete write_op to avoid memory leak in case mocks are used
     // if you need to change this, design your test so that storage is not a mock!
     if (write_op != nullptr) {

--- a/src/tests/rmb/test_rmb.cpp
+++ b/src/tests/rmb/test_rmb.cpp
@@ -11,11 +11,11 @@
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
-#include "rados-mail-object.h"
 #include <rados/librados.hpp>
 #include "../../librmb/rados-util.h"
 
 #include "../../librmb/rados-cluster-impl.h"
+#include "../../librmb/rados-mail.h"
 #include "../../librmb/rados-storage-impl.h"
 #include "../../librmb/tools/rmb/ls_cmd_parser.h"
 #include "../../librmb/tools/rmb/mailbox_tools.h"
@@ -92,7 +92,7 @@ TEST(rmb1, save_mail) {
   int init = tools.init_mailbox_dir();
   EXPECT_EQ(0, init);
 
-  librmb::RadosMailObject mail;
+  librmb::RadosMail mail;
   librados::bufferlist bl;
   bl.append("1");
   (*mail.get_metadata())["U"] = bl;
@@ -131,7 +131,7 @@ TEST(rmb1, rmb_commands_no_objects_found) {
 
   std::map<std::string, std::string> opts;
   librmb::RmbCommands rmb_cmd(&storage_mock, &cluster_mock, &opts);
-  std::vector<librmb::RadosMailObject *> mails;
+  std::vector<librmb::RadosMail *> mails;
   std::string search_string = "uid";
   const librados::NObjectIterator iter = librados::NObjectIterator::__EndObjectIterator;
   librados::IoCtx test_ioctx;
@@ -149,8 +149,8 @@ TEST(rmb1, rmb_command_filter_result) {
   opts["ls"] = "-";
   librmb::CmdLineParser parser(opts["ls"]);
   librmb::RmbCommands rmb_cmd(&storage_mock, &cluster_mock, &opts);
-  std::vector<librmb::RadosMailObject *> mails;
-  librmb::RadosMailObject obj1;
+  std::vector<librmb::RadosMail *> mails;
+  librmb::RadosMail obj1;
   obj1.set_oid("oid_1");
   obj1.set_mail_size(200);
   obj1.set_rados_save_date(time(NULL));
@@ -244,8 +244,8 @@ TEST(rmb1, rmb_command_filter_result2) {
   opts["ls"] = "-";
   librmb::CmdLineParser parser(opts["ls"]);
   librmb::RmbCommands rmb_cmd(&storage_mock, &cluster_mock, &opts);
-  std::vector<librmb::RadosMailObject *> mails;
-  librmb::RadosMailObject obj1;
+  std::vector<librmb::RadosMail *> mails;
+  librmb::RadosMail obj1;
   obj1.set_oid("oid_1");
   obj1.set_mail_size(200);
   obj1.set_rados_save_date(time(NULL));

--- a/src/tests/storage-mock-rbox/test_storage_mock_rbox.cpp
+++ b/src/tests/storage-mock-rbox/test_storage_mock_rbox.cpp
@@ -98,10 +98,10 @@ TEST_F(StorageTest, mail_save_to_inbox_storage_mock_no_rados_available) {
       .Times(AtLeast(1))
       .WillOnce(Return(-1));
 
-  librmb::RadosMailObject *test_obj = new librmb::RadosMailObject();
-  librmb::RadosMailObject *test_obj2 = new librmb::RadosMailObject();
+  librmb::RadosMail *test_obj = new librmb::RadosMail();
+  librmb::RadosMail *test_obj2 = new librmb::RadosMail();
 
-  EXPECT_CALL(*storage_mock, alloc_mail_object()).WillOnce(Return(test_obj)).WillOnce(Return(test_obj2));
+  EXPECT_CALL(*storage_mock, alloc_rados_mail()).WillOnce(Return(test_obj)).WillOnce(Return(test_obj2));
   // storage->ns_mgr->set_storage(storage_mock);
   storage->s = storage_mock;
 
@@ -193,10 +193,10 @@ TEST_F(StorageTest, exec_write_op_fails) {
   // EXPECT_CALL(*storage_mock, save_mail(Matcher<const std::string &>(_), _)).WillOnce(Return(0));
   // EXPECT_CALL(*storage_mock, read_mail(_, _)).WillOnce(Return(-2));
 
-  librmb::RadosMailObject *test_obj = new librmb::RadosMailObject();
-  librmb::RadosMailObject *test_obj2 = new librmb::RadosMailObject();
-  EXPECT_CALL(*storage_mock, alloc_mail_object()).Times(2).WillOnce(Return(test_obj)).WillOnce(Return(test_obj2));
-  EXPECT_CALL(*storage_mock, free_mail_object(_)).Times(2);
+  librmb::RadosMail *test_obj = new librmb::RadosMail();
+  librmb::RadosMail *test_obj2 = new librmb::RadosMail();
+  EXPECT_CALL(*storage_mock, alloc_rados_mail()).Times(2).WillOnce(Return(test_obj)).WillOnce(Return(test_obj2));
+  EXPECT_CALL(*storage_mock, free_rados_mail(_)).Times(2);
 
   delete storage->ms;
   librmbtest::RadosMetadataStorageProducerMock *ms_p_mock = new librmbtest::RadosMetadataStorageProducerMock();
@@ -318,11 +318,11 @@ TEST_F(StorageTest, write_op_fails) {
 
   EXPECT_CALL(*storage_mock, read_mail(_, _)).WillRepeatedly(Return(-2));
 
-  librmb::RadosMailObject *test_obj = new librmb::RadosMailObject();
-  librmb::RadosMailObject *test_obj2 = new librmb::RadosMailObject();
-  EXPECT_CALL(*storage_mock, alloc_mail_object()).Times(2).WillOnce(Return(test_obj)).WillOnce(Return(test_obj2));
+  librmb::RadosMail *test_obj = new librmb::RadosMail();
+  librmb::RadosMail *test_obj2 = new librmb::RadosMail();
+  EXPECT_CALL(*storage_mock, alloc_rados_mail()).Times(2).WillOnce(Return(test_obj)).WillOnce(Return(test_obj2));
 
-  EXPECT_CALL(*storage_mock, free_mail_object(_)).Times(2);
+  EXPECT_CALL(*storage_mock, free_rados_mail(_)).Times(2);
   delete storage->config;
   librmbtest::RadosDovecotCephCfgMock *cfg_mock = new librmbtest::RadosDovecotCephCfgMock();
   EXPECT_CALL(*cfg_mock, is_config_valid()).WillRepeatedly(Return(true));
@@ -424,9 +424,9 @@ TEST_F(StorageTest, mock_copy_failed_due_to_rados_err) {
       .WillRepeatedly(Return(true));
   // TODO: EXPECT_CALL(*storage_mock, set_metadata(_, _)).WillRepeatedly(Return(0));
 
-  librmb::RadosMailObject *test_obj_save = new librmb::RadosMailObject();
-  librmb::RadosMailObject *test_obj_save2 = new librmb::RadosMailObject();
-  EXPECT_CALL(*storage_mock, alloc_mail_object())
+  librmb::RadosMail *test_obj_save = new librmb::RadosMail();
+  librmb::RadosMail *test_obj_save2 = new librmb::RadosMail();
+  EXPECT_CALL(*storage_mock, alloc_rados_mail())
       .Times(2)
       .WillOnce(Return(test_obj_save))
       .WillOnce(Return(test_obj_save2));
@@ -451,15 +451,15 @@ TEST_F(StorageTest, mock_copy_failed_due_to_rados_err) {
   delete storage->s;
 
   librmbtest::RadosStorageMock *storage_mock_copy = new librmbtest::RadosStorageMock();
-  librmb::RadosMailObject *test_object = new librmb::RadosMailObject();
-  librmb::RadosMailObject *test_object2 = new librmb::RadosMailObject();
+  librmb::RadosMail *test_object = new librmb::RadosMail();
+  librmb::RadosMail *test_object2 = new librmb::RadosMail();
 
   librmb::RadosMetadata recv_date = librmb::RadosMetadata(librmb::RBOX_METADATA_RECEIVED_TIME, time(NULL));
   test_object->add_metadata(recv_date);
   librmb::RadosMetadata guid = librmb::RadosMetadata(librmb::RBOX_METADATA_GUID, "67ffff24efc0e559194f00009c60b9f7");
   test_object->add_metadata(guid);
 
-  EXPECT_CALL(*storage_mock_copy, alloc_mail_object())
+  EXPECT_CALL(*storage_mock_copy, alloc_rados_mail())
       .Times(2)
       .WillOnce(Return(test_object))
       .WillOnce(Return(test_object2));

--- a/src/tests/storage-rbox/it_test_copy_rbox.cpp
+++ b/src/tests/storage-rbox/it_test_copy_rbox.cpp
@@ -122,9 +122,9 @@ TEST_F(StorageTest, mail_copy_mail_in_inbox) {
   }
   struct rbox_storage *r_storage = (struct rbox_storage *)box->storage;
   librados::NObjectIterator iter(r_storage->s->get_io_ctx().nobjects_begin());
-  std::vector<librmb::RadosMailObject *> objects;
+  std::vector<librmb::RadosMail *> objects;
   while (iter != librados::NObjectIterator::__EndObjectIterator) {
-    librmb::RadosMailObject *obj = new librmb::RadosMailObject();
+    librmb::RadosMail *obj = new librmb::RadosMail();
     obj->set_oid((*iter).get_oid());
     r_storage->ms->get_storage()->load_metadata(obj);
     objects.push_back(obj);
@@ -134,8 +134,8 @@ TEST_F(StorageTest, mail_copy_mail_in_inbox) {
   // compare objects
   ASSERT_EQ(2, (int)objects.size());
 
-  librmb::RadosMailObject *mail1 = objects[0];
-  librmb::RadosMailObject *mail2 = objects[1];
+  librmb::RadosMail *mail1 = objects[0];
+  librmb::RadosMail *mail2 = objects[1];
 
   std::string val;
   std::string val2;

--- a/src/tests/storage-rbox/it_test_copy_rbox.cpp
+++ b/src/tests/storage-rbox/it_test_copy_rbox.cpp
@@ -137,32 +137,67 @@ TEST_F(StorageTest, mail_copy_mail_in_inbox) {
   librmb::RadosMailObject *mail1 = objects[0];
   librmb::RadosMailObject *mail2 = objects[1];
 
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_OLDV1_FLAGS),
-            mail2->get_metadata(librmb::RBOX_METADATA_OLDV1_FLAGS));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_EXT_REF), mail2->get_metadata(librmb::RBOX_METADATA_EXT_REF));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_FROM_ENVELOPE),
-            mail2->get_metadata(librmb::RBOX_METADATA_FROM_ENVELOPE));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_GUID), mail2->get_metadata(librmb::RBOX_METADATA_GUID));
+  std::string val;
+  std::string val2;
+  mail1->get_metadata(librmb::RBOX_METADATA_OLDV1_FLAGS, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_OLDV1_FLAGS, &val2);
+  ASSERT_EQ(val, val2);
 
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_MAILBOX_GUID),
-            mail2->get_metadata(librmb::RBOX_METADATA_MAILBOX_GUID));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_ORIG_MAILBOX),
-            mail2->get_metadata(librmb::RBOX_METADATA_ORIG_MAILBOX));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_PHYSICAL_SIZE),
-            mail2->get_metadata(librmb::RBOX_METADATA_PHYSICAL_SIZE));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_POP3_ORDER),
-            mail2->get_metadata(librmb::RBOX_METADATA_POP3_ORDER));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_POP3_UIDL), mail2->get_metadata(librmb::RBOX_METADATA_POP3_UIDL));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_PVT_FLAGS), mail2->get_metadata(librmb::RBOX_METADATA_PVT_FLAGS));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_RECEIVED_TIME),
-            mail2->get_metadata(librmb::RBOX_METADATA_RECEIVED_TIME));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_VERSION), mail2->get_metadata(librmb::RBOX_METADATA_VERSION));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_VIRTUAL_SIZE),
-            mail2->get_metadata(librmb::RBOX_METADATA_VIRTUAL_SIZE));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_OLDV1_SAVE_TIME),
-            mail2->get_metadata(librmb::RBOX_METADATA_OLDV1_SAVE_TIME));
+  mail1->get_metadata(librmb::RBOX_METADATA_EXT_REF, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_EXT_REF, &val2);
+  ASSERT_EQ(val, val2);
 
-  ASSERT_NE(mail1->get_metadata(librmb::RBOX_METADATA_MAIL_UID), mail2->get_metadata(librmb::RBOX_METADATA_MAIL_UID));
+  mail1->get_metadata(librmb::RBOX_METADATA_FROM_ENVELOPE, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_FROM_ENVELOPE, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_GUID, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_GUID, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_MAILBOX_GUID, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_MAILBOX_GUID, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_ORIG_MAILBOX, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_ORIG_MAILBOX, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_PHYSICAL_SIZE, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_PHYSICAL_SIZE, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_POP3_ORDER, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_POP3_ORDER, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_POP3_UIDL, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_POP3_UIDL, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_PVT_FLAGS, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_PVT_FLAGS, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_RECEIVED_TIME, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_RECEIVED_TIME, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_VERSION, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_VERSION, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_VIRTUAL_SIZE, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_VIRTUAL_SIZE, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_OLDV1_SAVE_TIME, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_OLDV1_SAVE_TIME, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_MAIL_UID, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_MAIL_UID, &val2);
+  ASSERT_NE(val, val2);
 
   ASSERT_EQ(2, (int)box->index->map->hdr.messages_count);
   delete mail1;

--- a/src/tests/storage-rbox/it_test_copy_rbox_alt.cpp
+++ b/src/tests/storage-rbox/it_test_copy_rbox_alt.cpp
@@ -117,13 +117,13 @@ TEST_F(StorageTest, mail_copy_mail_in_inbox) {
     mail_update_flags(mail, MODIFY_ADD, (enum mail_flags)MAIL_INDEX_MAIL_FLAG_BACKEND);
     rbox_get_index_record(mail);
     struct rbox_mail *r_mail = (struct rbox_mail *)mail;
-    i_debug("end %s", r_mail->mail_object->get_oid().c_str());
+    i_debug("end %s", r_mail->rados_mail->get_oid().c_str());
     if (rbox_open_rados_connection(box, true) < 0) {
       FAIL() << "connection error alt";
     } else {
       struct rbox_mailbox *mbox = (struct rbox_mailbox *)box;
       // MOVE TO ALT
-      std::string oid = r_mail->mail_object->get_oid();
+      std::string oid = r_mail->rados_mail->get_oid();
       librmb::RadosUtils::move_to_alt(oid, mbox->storage->s, mbox->storage->alt, mbox->storage->ms, false);
     }
 

--- a/src/tests/storage-rbox/it_test_copy_rbox_alt.cpp
+++ b/src/tests/storage-rbox/it_test_copy_rbox_alt.cpp
@@ -148,9 +148,9 @@ TEST_F(StorageTest, mail_copy_mail_in_inbox) {
 
   librados::NObjectIterator iter_alt(r_storage->alt->get_io_ctx().nobjects_begin());
   r_storage->ms->get_storage()->set_io_ctx(&r_storage->alt->get_io_ctx());
-  std::vector<librmb::RadosMailObject *> objects_alt;
+  std::vector<librmb::RadosMail *> objects_alt;
   while (iter_alt != librados::NObjectIterator::__EndObjectIterator) {
-    librmb::RadosMailObject *obj = new librmb::RadosMailObject();
+    librmb::RadosMail *obj = new librmb::RadosMail();
     obj->set_oid((*iter_alt).get_oid());
     r_storage->ms->get_storage()->load_metadata(obj);
     objects_alt.push_back(obj);
@@ -158,8 +158,8 @@ TEST_F(StorageTest, mail_copy_mail_in_inbox) {
   }
   r_storage->ms->get_storage()->set_io_ctx(&r_storage->s->get_io_ctx());
   ASSERT_EQ(2, (int)objects_alt.size());
-  librmb::RadosMailObject *mail1 = objects_alt[0];
-  librmb::RadosMailObject *mail2 = objects_alt[1];
+  librmb::RadosMail *mail1 = objects_alt[0];
+  librmb::RadosMail *mail2 = objects_alt[1];
 
   std::string val;
   std::string val2;

--- a/src/tests/storage-rbox/it_test_copy_rbox_alt.cpp
+++ b/src/tests/storage-rbox/it_test_copy_rbox_alt.cpp
@@ -161,32 +161,67 @@ TEST_F(StorageTest, mail_copy_mail_in_inbox) {
   librmb::RadosMailObject *mail1 = objects_alt[0];
   librmb::RadosMailObject *mail2 = objects_alt[1];
 
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_OLDV1_FLAGS),
-            mail2->get_metadata(librmb::RBOX_METADATA_OLDV1_FLAGS));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_EXT_REF), mail2->get_metadata(librmb::RBOX_METADATA_EXT_REF));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_FROM_ENVELOPE),
-            mail2->get_metadata(librmb::RBOX_METADATA_FROM_ENVELOPE));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_GUID), mail2->get_metadata(librmb::RBOX_METADATA_GUID));
+  std::string val;
+  std::string val2;
+  mail1->get_metadata(librmb::RBOX_METADATA_OLDV1_FLAGS, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_OLDV1_FLAGS, &val2);
+  ASSERT_EQ(val, val2);
 
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_MAILBOX_GUID),
-            mail2->get_metadata(librmb::RBOX_METADATA_MAILBOX_GUID));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_ORIG_MAILBOX),
-            mail2->get_metadata(librmb::RBOX_METADATA_ORIG_MAILBOX));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_PHYSICAL_SIZE),
-            mail2->get_metadata(librmb::RBOX_METADATA_PHYSICAL_SIZE));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_POP3_ORDER),
-            mail2->get_metadata(librmb::RBOX_METADATA_POP3_ORDER));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_POP3_UIDL), mail2->get_metadata(librmb::RBOX_METADATA_POP3_UIDL));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_PVT_FLAGS), mail2->get_metadata(librmb::RBOX_METADATA_PVT_FLAGS));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_RECEIVED_TIME),
-            mail2->get_metadata(librmb::RBOX_METADATA_RECEIVED_TIME));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_VERSION), mail2->get_metadata(librmb::RBOX_METADATA_VERSION));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_VIRTUAL_SIZE),
-            mail2->get_metadata(librmb::RBOX_METADATA_VIRTUAL_SIZE));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_OLDV1_SAVE_TIME),
-            mail2->get_metadata(librmb::RBOX_METADATA_OLDV1_SAVE_TIME));
+  mail1->get_metadata(librmb::RBOX_METADATA_EXT_REF, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_EXT_REF, &val2);
+  ASSERT_EQ(val, val2);
 
-  ASSERT_NE(mail1->get_metadata(librmb::RBOX_METADATA_MAIL_UID), mail2->get_metadata(librmb::RBOX_METADATA_MAIL_UID));
+  mail1->get_metadata(librmb::RBOX_METADATA_FROM_ENVELOPE, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_FROM_ENVELOPE, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_GUID, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_GUID, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_MAILBOX_GUID, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_MAILBOX_GUID, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_ORIG_MAILBOX, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_ORIG_MAILBOX, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_PHYSICAL_SIZE, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_PHYSICAL_SIZE, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_POP3_ORDER, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_POP3_ORDER, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_POP3_UIDL, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_POP3_UIDL, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_PVT_FLAGS, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_PVT_FLAGS, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_RECEIVED_TIME, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_RECEIVED_TIME, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_VERSION, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_VERSION, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_VIRTUAL_SIZE, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_VIRTUAL_SIZE, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_OLDV1_SAVE_TIME, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_OLDV1_SAVE_TIME, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_MAIL_UID, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_MAIL_UID, &val2);
+  ASSERT_NE(val, val2);
 
   ASSERT_EQ(2, (int)box->index->map->hdr.messages_count);
   r_storage->alt->delete_mail(mail1);

--- a/src/tests/storage-rbox/it_test_copy_rbox_fail.cpp
+++ b/src/tests/storage-rbox/it_test_copy_rbox_fail.cpp
@@ -104,8 +104,8 @@ TEST_F(StorageTest, mail_copy_mail_in_inbox) {
     save_ctx = mailbox_save_alloc(desttrans);  // src save context
     struct rbox_mail *rmail = (struct rbox_mail *)mail;
     /* simulate mail object does not exist */
-    i_debug("oid: %s", rmail->mail_object->get_oid().c_str());
-    rmail->mail_object->set_oid("dummy!!!");
+    i_debug("oid: %s", rmail->rados_mail->get_oid().c_str());
+    rmail->rados_mail->set_oid("dummy!!!");
     mailbox_save_copy_flags(save_ctx, mail);
 
     int ret2 = mailbox_copy(&save_ctx, mail);

--- a/src/tests/storage-rbox/it_test_doveadm_backup_rbox.cpp
+++ b/src/tests/storage-rbox/it_test_doveadm_backup_rbox.cpp
@@ -129,9 +129,9 @@ TEST_F(StorageTest, mail_doveadm_backup_copy_mail_in_inbox) {
 
   struct rbox_storage *r_storage = (struct rbox_storage *)box->storage;
   librados::NObjectIterator iter(r_storage->s->get_io_ctx().nobjects_begin());
-  std::vector<librmb::RadosMailObject *> objects;
+  std::vector<librmb::RadosMail *> objects;
   while (iter != r_storage->s->get_io_ctx().nobjects_end()) {
-    librmb::RadosMailObject *obj = new librmb::RadosMailObject();
+    librmb::RadosMail *obj = new librmb::RadosMail();
     obj->set_oid((*iter).get_oid());
     r_storage->ms->get_storage()->load_metadata(obj);
     objects.push_back(obj);
@@ -141,8 +141,8 @@ TEST_F(StorageTest, mail_doveadm_backup_copy_mail_in_inbox) {
   // compare objects
   ASSERT_EQ(2, (int)objects.size());
 
-  librmb::RadosMailObject *mail1 = objects[0];
-  librmb::RadosMailObject *mail2 = objects[1];
+  librmb::RadosMail *mail1 = objects[0];
+  librmb::RadosMail *mail2 = objects[1];
 
   std::string val;
   std::string val2;

--- a/src/tests/storage-rbox/it_test_doveadm_backup_rbox.cpp
+++ b/src/tests/storage-rbox/it_test_doveadm_backup_rbox.cpp
@@ -144,33 +144,67 @@ TEST_F(StorageTest, mail_doveadm_backup_copy_mail_in_inbox) {
   librmb::RadosMailObject *mail1 = objects[0];
   librmb::RadosMailObject *mail2 = objects[1];
 
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_OLDV1_FLAGS),
-            mail2->get_metadata(librmb::RBOX_METADATA_OLDV1_FLAGS));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_EXT_REF), mail2->get_metadata(librmb::RBOX_METADATA_EXT_REF));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_FROM_ENVELOPE),
-            mail2->get_metadata(librmb::RBOX_METADATA_FROM_ENVELOPE));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_GUID), mail2->get_metadata(librmb::RBOX_METADATA_GUID));
+  std::string val;
+  std::string val2;
+  mail1->get_metadata(librmb::RBOX_METADATA_OLDV1_FLAGS, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_OLDV1_FLAGS, &val2);
+  ASSERT_EQ(val, val2);
 
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_MAILBOX_GUID),
-            mail2->get_metadata(librmb::RBOX_METADATA_MAILBOX_GUID));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_ORIG_MAILBOX),
-            mail2->get_metadata(librmb::RBOX_METADATA_ORIG_MAILBOX));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_PHYSICAL_SIZE),
-            mail2->get_metadata(librmb::RBOX_METADATA_PHYSICAL_SIZE));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_POP3_ORDER),
-            mail2->get_metadata(librmb::RBOX_METADATA_POP3_ORDER));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_POP3_UIDL), mail2->get_metadata(librmb::RBOX_METADATA_POP3_UIDL));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_PVT_FLAGS), mail2->get_metadata(librmb::RBOX_METADATA_PVT_FLAGS));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_RECEIVED_TIME),
-            mail2->get_metadata(librmb::RBOX_METADATA_RECEIVED_TIME));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_VERSION), mail2->get_metadata(librmb::RBOX_METADATA_VERSION));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_VIRTUAL_SIZE),
-            mail2->get_metadata(librmb::RBOX_METADATA_VIRTUAL_SIZE));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_OLDV1_SAVE_TIME),
-            mail2->get_metadata(librmb::RBOX_METADATA_OLDV1_SAVE_TIME));
+  mail1->get_metadata(librmb::RBOX_METADATA_EXT_REF, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_EXT_REF, &val2);
+  ASSERT_EQ(val, val2);
 
-  ASSERT_NE(mail1->get_metadata(librmb::RBOX_METADATA_MAIL_UID), mail2->get_metadata(librmb::RBOX_METADATA_MAIL_UID));
+  mail1->get_metadata(librmb::RBOX_METADATA_FROM_ENVELOPE, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_FROM_ENVELOPE, &val2);
+  ASSERT_EQ(val, val2);
 
+  mail1->get_metadata(librmb::RBOX_METADATA_GUID, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_GUID, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_MAILBOX_GUID, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_MAILBOX_GUID, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_ORIG_MAILBOX, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_ORIG_MAILBOX, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_PHYSICAL_SIZE, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_PHYSICAL_SIZE, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_POP3_ORDER, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_POP3_ORDER, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_POP3_UIDL, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_POP3_UIDL, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_PVT_FLAGS, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_PVT_FLAGS, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_RECEIVED_TIME, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_RECEIVED_TIME, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_VERSION, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_VERSION, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_VIRTUAL_SIZE, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_VIRTUAL_SIZE, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_OLDV1_SAVE_TIME, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_OLDV1_SAVE_TIME, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_MAIL_UID, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_MAIL_UID, &val2);
+  ASSERT_NE(val, val2);
   ASSERT_EQ(2, (int)box->index->map->hdr.messages_count);
   delete mail1;
   delete mail2;

--- a/src/tests/storage-rbox/it_test_lda_rbox.cpp
+++ b/src/tests/storage-rbox/it_test_lda_rbox.cpp
@@ -136,9 +136,9 @@ TEST_F(StorageTest, mail_lda_copy_mail_in_inbox) {
 
   struct rbox_storage *r_storage = (struct rbox_storage *)box->storage;
   librados::NObjectIterator iter(r_storage->s->get_io_ctx().nobjects_begin());
-  std::vector<librmb::RadosMailObject *> objects;
+  std::vector<librmb::RadosMail *> objects;
   while (iter != r_storage->s->get_io_ctx().nobjects_end()) {
-    librmb::RadosMailObject *obj = new librmb::RadosMailObject();
+    librmb::RadosMail *obj = new librmb::RadosMail();
     obj->set_oid((*iter).get_oid());
     r_storage->ms->get_storage()->load_metadata(obj);
     objects.push_back(obj);
@@ -148,8 +148,8 @@ TEST_F(StorageTest, mail_lda_copy_mail_in_inbox) {
   // compare objects
   ASSERT_EQ(2, (int)objects.size());
 
-  librmb::RadosMailObject *mail1 = objects[0];
-  librmb::RadosMailObject *mail2 = objects[1];
+  librmb::RadosMail *mail1 = objects[0];
+  librmb::RadosMail *mail2 = objects[1];
 
   std::string val;
   std::string val2;

--- a/src/tests/storage-rbox/it_test_lda_rbox.cpp
+++ b/src/tests/storage-rbox/it_test_lda_rbox.cpp
@@ -151,32 +151,67 @@ TEST_F(StorageTest, mail_lda_copy_mail_in_inbox) {
   librmb::RadosMailObject *mail1 = objects[0];
   librmb::RadosMailObject *mail2 = objects[1];
 
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_OLDV1_FLAGS),
-            mail2->get_metadata(librmb::RBOX_METADATA_OLDV1_FLAGS));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_EXT_REF), mail2->get_metadata(librmb::RBOX_METADATA_EXT_REF));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_FROM_ENVELOPE),
-            mail2->get_metadata(librmb::RBOX_METADATA_FROM_ENVELOPE));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_GUID), mail2->get_metadata(librmb::RBOX_METADATA_GUID));
+  std::string val;
+  std::string val2;
+  mail1->get_metadata(librmb::RBOX_METADATA_OLDV1_FLAGS, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_OLDV1_FLAGS, &val2);
+  ASSERT_EQ(val, val2);
 
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_MAILBOX_GUID),
-            mail2->get_metadata(librmb::RBOX_METADATA_MAILBOX_GUID));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_ORIG_MAILBOX),
-            mail2->get_metadata(librmb::RBOX_METADATA_ORIG_MAILBOX));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_PHYSICAL_SIZE),
-            mail2->get_metadata(librmb::RBOX_METADATA_PHYSICAL_SIZE));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_POP3_ORDER),
-            mail2->get_metadata(librmb::RBOX_METADATA_POP3_ORDER));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_POP3_UIDL), mail2->get_metadata(librmb::RBOX_METADATA_POP3_UIDL));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_PVT_FLAGS), mail2->get_metadata(librmb::RBOX_METADATA_PVT_FLAGS));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_RECEIVED_TIME),
-            mail2->get_metadata(librmb::RBOX_METADATA_RECEIVED_TIME));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_VERSION), mail2->get_metadata(librmb::RBOX_METADATA_VERSION));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_VIRTUAL_SIZE),
-            mail2->get_metadata(librmb::RBOX_METADATA_VIRTUAL_SIZE));
-  ASSERT_EQ(mail1->get_metadata(librmb::RBOX_METADATA_OLDV1_SAVE_TIME),
-            mail2->get_metadata(librmb::RBOX_METADATA_OLDV1_SAVE_TIME));
+  mail1->get_metadata(librmb::RBOX_METADATA_EXT_REF, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_EXT_REF, &val2);
+  ASSERT_EQ(val, val2);
 
-  ASSERT_NE(mail1->get_metadata(librmb::RBOX_METADATA_MAIL_UID), mail2->get_metadata(librmb::RBOX_METADATA_MAIL_UID));
+  mail1->get_metadata(librmb::RBOX_METADATA_FROM_ENVELOPE, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_FROM_ENVELOPE, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_GUID, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_GUID, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_MAILBOX_GUID, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_MAILBOX_GUID, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_ORIG_MAILBOX, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_ORIG_MAILBOX, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_PHYSICAL_SIZE, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_PHYSICAL_SIZE, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_POP3_ORDER, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_POP3_ORDER, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_POP3_UIDL, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_POP3_UIDL, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_PVT_FLAGS, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_PVT_FLAGS, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_RECEIVED_TIME, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_RECEIVED_TIME, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_VERSION, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_VERSION, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_VIRTUAL_SIZE, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_VIRTUAL_SIZE, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_OLDV1_SAVE_TIME, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_OLDV1_SAVE_TIME, &val2);
+  ASSERT_EQ(val, val2);
+
+  mail1->get_metadata(librmb::RBOX_METADATA_MAIL_UID, &val);
+  mail2->get_metadata(librmb::RBOX_METADATA_MAIL_UID, &val2);
+  ASSERT_NE(val, val2);
 
   ASSERT_EQ(2, (int)box->index->map->hdr.messages_count);
   delete mail1;

--- a/src/tests/storage-rbox/it_test_move_rbox.cpp
+++ b/src/tests/storage-rbox/it_test_move_rbox.cpp
@@ -120,9 +120,9 @@ TEST_F(StorageTest, mail_copy_mail_in_inbox) {
 
   struct rbox_storage *r_storage = (struct rbox_storage *)box->storage;
   librados::NObjectIterator iter(r_storage->s->get_io_ctx().nobjects_begin());
-  std::vector<librmb::RadosMailObject *> objects;
+  std::vector<librmb::RadosMail *> objects;
   while (iter != r_storage->s->get_io_ctx().nobjects_end()) {
-    librmb::RadosMailObject *obj = new librmb::RadosMailObject();
+    librmb::RadosMail *obj = new librmb::RadosMail();
     obj->set_oid((*iter).get_oid());
     r_storage->ms->get_storage()->load_metadata(obj);
     objects.push_back(obj);
@@ -131,7 +131,7 @@ TEST_F(StorageTest, mail_copy_mail_in_inbox) {
 
   // compare objects
   ASSERT_EQ(1, (int)objects.size());
-  librmb::RadosMailObject *mail1 = objects[0];
+  librmb::RadosMail *mail1 = objects[0];
 
   std::string val;
   std::string val2;

--- a/src/tests/storage-rbox/it_test_move_rbox.cpp
+++ b/src/tests/storage-rbox/it_test_move_rbox.cpp
@@ -133,13 +133,23 @@ TEST_F(StorageTest, mail_copy_mail_in_inbox) {
   ASSERT_EQ(1, (int)objects.size());
   librmb::RadosMailObject *mail1 = objects[0];
 
-  ASSERT_NE(mail1->get_metadata(librmb::RBOX_METADATA_MAIL_UID), "");
-  ASSERT_NE(mail1->get_metadata(librmb::RBOX_METADATA_GUID), "");
-  ASSERT_NE(mail1->get_metadata(librmb::RBOX_METADATA_MAILBOX_GUID), "");
-  ASSERT_NE(mail1->get_metadata(librmb::RBOX_METADATA_PHYSICAL_SIZE), "");
-  ASSERT_NE(mail1->get_metadata(librmb::RBOX_METADATA_VIRTUAL_SIZE), "");
-  ASSERT_NE(mail1->get_metadata(librmb::RBOX_METADATA_RECEIVED_TIME), "");
-  ASSERT_NE(mail1->get_metadata(librmb::RBOX_METADATA_ORIG_MAILBOX), "");
+  std::string val;
+  std::string val2;
+
+  mail1->get_metadata(librmb::RBOX_METADATA_MAIL_UID, &val);
+  ASSERT_NE(val, val2);
+  mail1->get_metadata(librmb::RBOX_METADATA_GUID, &val);
+  ASSERT_NE(val, val2);
+  mail1->get_metadata(librmb::RBOX_METADATA_MAILBOX_GUID, &val);
+  ASSERT_NE(val, val2);
+  mail1->get_metadata(librmb::RBOX_METADATA_PHYSICAL_SIZE, &val);
+  ASSERT_NE(val, val2);
+  mail1->get_metadata(librmb::RBOX_METADATA_VIRTUAL_SIZE, &val);
+  ASSERT_NE(val, val2);
+  mail1->get_metadata(librmb::RBOX_METADATA_RECEIVED_TIME, &val);
+  ASSERT_NE(val, val2);
+  mail1->get_metadata(librmb::RBOX_METADATA_ORIG_MAILBOX, &val);
+  ASSERT_NE(val, val2);
 
   ASSERT_EQ(1, (int)box->index->map->hdr.messages_count);
   delete mail1;

--- a/src/tests/storage-rbox/it_test_move_rbox_alt.cpp
+++ b/src/tests/storage-rbox/it_test_move_rbox_alt.cpp
@@ -116,13 +116,13 @@ TEST_F(StorageTest, mail_copy_mail_in_inbox) {
     mail_update_flags(mail, MODIFY_ADD, (enum mail_flags)MAIL_INDEX_MAIL_FLAG_BACKEND);
     rbox_get_index_record(mail);
     struct rbox_mail *r_mail = (struct rbox_mail *)mail;
-    i_debug("end %s", r_mail->mail_object->get_oid().c_str());
+    i_debug("end %s", r_mail->rados_mail->get_oid().c_str());
     if (rbox_open_rados_connection(box, true) < 0) {
       FAIL() << "connection error alt";
     } else {
       struct rbox_mailbox *mbox = (struct rbox_mailbox *)box;
       // MOVE TO ALT
-      std::string oid = r_mail->mail_object->get_oid();
+      std::string oid = r_mail->rados_mail->get_oid();
       librmb::RadosUtils::move_to_alt(oid, mbox->storage->s, mbox->storage->alt, mbox->storage->ms, false);
     }
 

--- a/src/tests/storage-rbox/it_test_move_rbox_alt.cpp
+++ b/src/tests/storage-rbox/it_test_move_rbox_alt.cpp
@@ -159,13 +159,23 @@ TEST_F(StorageTest, mail_copy_mail_in_inbox) {
   ASSERT_EQ(1, (int)objects.size());
   librmb::RadosMailObject *mail1 = objects[0];
 
-  ASSERT_NE(mail1->get_metadata(librmb::RBOX_METADATA_MAIL_UID), "");
-  ASSERT_NE(mail1->get_metadata(librmb::RBOX_METADATA_GUID), "");
-  ASSERT_NE(mail1->get_metadata(librmb::RBOX_METADATA_MAILBOX_GUID), "");
-  ASSERT_NE(mail1->get_metadata(librmb::RBOX_METADATA_PHYSICAL_SIZE), "");
-  ASSERT_NE(mail1->get_metadata(librmb::RBOX_METADATA_VIRTUAL_SIZE), "");
-  ASSERT_NE(mail1->get_metadata(librmb::RBOX_METADATA_RECEIVED_TIME), "");
-  ASSERT_NE(mail1->get_metadata(librmb::RBOX_METADATA_ORIG_MAILBOX), "");
+  std::string val;
+  std::string val2;
+
+  mail1->get_metadata(librmb::RBOX_METADATA_MAIL_UID, &val);
+  ASSERT_NE(val, val2);
+  mail1->get_metadata(librmb::RBOX_METADATA_GUID, &val);
+  ASSERT_NE(val, val2);
+  mail1->get_metadata(librmb::RBOX_METADATA_MAILBOX_GUID, &val);
+  ASSERT_NE(val, val2);
+  mail1->get_metadata(librmb::RBOX_METADATA_PHYSICAL_SIZE, &val);
+  ASSERT_NE(val, val2);
+  mail1->get_metadata(librmb::RBOX_METADATA_VIRTUAL_SIZE, &val);
+  ASSERT_NE(val, val2);
+  mail1->get_metadata(librmb::RBOX_METADATA_RECEIVED_TIME, &val);
+  ASSERT_NE(val, val2);
+  mail1->get_metadata(librmb::RBOX_METADATA_ORIG_MAILBOX, &val);
+  ASSERT_NE(val, val2);
 
   ASSERT_EQ(1, (int)box->index->map->hdr.messages_count);
   r_storage->alt->delete_mail(mail1);

--- a/src/tests/storage-rbox/it_test_move_rbox_alt.cpp
+++ b/src/tests/storage-rbox/it_test_move_rbox_alt.cpp
@@ -146,9 +146,9 @@ TEST_F(StorageTest, mail_copy_mail_in_inbox) {
 
   librados::NObjectIterator iter(r_storage->alt->get_io_ctx().nobjects_begin());
   r_storage->ms->get_storage()->set_io_ctx(&r_storage->alt->get_io_ctx());
-  std::vector<librmb::RadosMailObject *> objects;
+  std::vector<librmb::RadosMail *> objects;
   while (iter != r_storage->alt->get_io_ctx().nobjects_end()) {
-    librmb::RadosMailObject *obj = new librmb::RadosMailObject();
+    librmb::RadosMail *obj = new librmb::RadosMail();
     obj->set_oid((*iter).get_oid());
     r_storage->ms->get_storage()->load_metadata(obj);
     objects.push_back(obj);
@@ -157,7 +157,7 @@ TEST_F(StorageTest, mail_copy_mail_in_inbox) {
 
   // compare objects
   ASSERT_EQ(1, (int)objects.size());
-  librmb::RadosMailObject *mail1 = objects[0];
+  librmb::RadosMail *mail1 = objects[0];
 
   std::string val;
   std::string val2;

--- a/src/tests/storage-rbox/it_test_read_mail_failed_rbox.cpp
+++ b/src/tests/storage-rbox/it_test_read_mail_failed_rbox.cpp
@@ -107,7 +107,7 @@ TEST_F(StorageTest, mail_copy_mail_in_inbox) {
     struct rbox_storage *r_storage = (struct rbox_storage *)box->storage;
 
     // delete mail.
-    r_storage->s->delete_mail(r_mail->mail_object);
+    r_storage->s->delete_mail(r_mail->rados_mail);
 
     int ret2 = mail_get_stream(mail, &hdr_size, &body_size, &input);
     EXPECT_EQ(ret2, -1);

--- a/src/tests/storage-rbox/it_test_read_mail_rbox_alt.cpp
+++ b/src/tests/storage-rbox/it_test_read_mail_rbox_alt.cpp
@@ -116,13 +116,13 @@ TEST_F(StorageTest, mail_copy_mail_in_inbox) {
     mail_update_flags(mail, MODIFY_ADD, (enum mail_flags)MAIL_INDEX_MAIL_FLAG_BACKEND);
     rbox_get_index_record(mail);
     struct rbox_mail *r_mail = (struct rbox_mail *)mail;
-    i_debug("end %s", r_mail->mail_object->get_oid().c_str());
+    i_debug("end %s", r_mail->rados_mail->get_oid().c_str());
     if (rbox_open_rados_connection(box, true) < 0) {
       FAIL() << "connection error alt";
     } else {
       struct rbox_mailbox *mbox = (struct rbox_mailbox *)box;
       // MOVE TO ALT
-      std::string oid = r_mail->mail_object->get_oid();
+      std::string oid = r_mail->rados_mail->get_oid();
       librmb::RadosUtils::move_to_alt(oid, mbox->storage->s, mbox->storage->alt, mbox->storage->ms, false);
     }
 

--- a/src/tests/storage-rbox/it_test_storage_rbox.cpp
+++ b/src/tests/storage-rbox/it_test_storage_rbox.cpp
@@ -218,7 +218,8 @@ TEST_F(StorageTest, mail_save_to_inbox_with_flags) {
       librmb::RadosMailObject obj;
       obj.set_oid((*iter).get_oid());
       r_storage->ms->get_storage()->load_metadata(&obj);
-      std::string str = obj.get_metadata(librmb::RBOX_METADATA_OLDV1_FLAGS);
+      std::string str;
+      obj.get_metadata(librmb::RBOX_METADATA_OLDV1_FLAGS, &str);
       uint8_t flags;
       librmb::RadosUtils::string_to_flags(str, &flags);
       EXPECT_EQ(0x01, flags);

--- a/src/tests/storage-rbox/it_test_storage_rbox.cpp
+++ b/src/tests/storage-rbox/it_test_storage_rbox.cpp
@@ -170,7 +170,7 @@ TEST_F(StorageTest, mail_save_to_inbox_with_flags) {
     ssize_t ret;
     struct mail_save_data *mdata = &r_ctx->ctx.data;
 
-    test_oid = r_ctx->current_object->get_oid();
+    test_oid = r_ctx->rados_mail->get_oid();
 
     do {
       if (mailbox_save_continue(save_ctx) < 0) {
@@ -215,7 +215,7 @@ TEST_F(StorageTest, mail_save_to_inbox_with_flags) {
   librados::NObjectIterator iter(r_storage->s->get_io_ctx().nobjects_begin());
   while (iter != r_storage->s->get_io_ctx().nobjects_end()) {
     if (test_oid.compare((*iter).get_oid()) == 0) {
-      librmb::RadosMailObject obj;
+      librmb::RadosMail obj;
       obj.set_oid((*iter).get_oid());
       r_storage->ms->get_storage()->load_metadata(&obj);
       std::string str;

--- a/src/tests/test-utils/it_utils.cpp
+++ b/src/tests/test-utils/it_utils.cpp
@@ -7,12 +7,15 @@
  * Foundation.  See file COPYING.
  */
 
-#include "../test-utils/it_utils.h"
+#include "it_utils.h"
+
+#include <string>
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "../mocks/mock_test.h"
 #include "istream-bufferlist.h"
+
 using ::testing::AtLeast;
 using ::testing::Return;
 using ::testing::_;


### PR DESCRIPTION
The bugfix makes sure that all available mails will be exported if one of the mail objects no longer exist in rados storage. 
In short, the solution is to set the error MAIL_ERROR_EXPUNGED for missing mails, in this case, the backup process will ignore this mail and proceed with next mail in index. 

Additionally i did some code cleanup.