### PR TITLE
Jrse #222

### DIFF
--- a/src/storage-rbox/rbox-mail.cpp
+++ b/src/storage-rbox/rbox-mail.cpp
@@ -46,7 +46,7 @@ using librmb::rbox_metadata_key;
 void rbox_mail_set_expunged(struct rbox_mail *mail) {
   FUNC_START();
   // only set mail to expunge. see #222 rbox_set_expunge => index rebuild!
-  mail_set_expunged(_mail);
+  mail_set_expunged((struct mail *)mail);
   FUNC_END();
 }
 

--- a/src/storage-rbox/rbox-mail.cpp
+++ b/src/storage-rbox/rbox-mail.cpp
@@ -45,18 +45,8 @@ using librmb::rbox_metadata_key;
 
 void rbox_mail_set_expunged(struct rbox_mail *mail) {
   FUNC_START();
-  struct mail *_mail = &mail->imail.mail.mail;
-
-  mail_index_refresh(_mail->box->index);
-  if (mail_index_is_expunged(_mail->transaction->view, _mail->seq)) {
-    mail_set_expunged(_mail);
-  } else {
-    mail_storage_set_critical(_mail->box->storage, "rbox %s: Unexpectedly lost uid=%u", mailbox_get_path(_mail->box),
-                              _mail->uid);
-    /* the message was probably just purged */
-    mail_storage_set_error(_mail->box->storage, MAIL_ERROR_EXPUNGED, "requested messages no longer exist.");
-    rbox_set_mailbox_corrupted(_mail->box);
-  }
+  // only set mail to expunge. see #222 rbox_set_expunge => index rebuild!
+  mail_set_expunged(_mail);
   FUNC_END();
 }
 

--- a/src/tests/storage-rbox/it_test_read_mail_failed_rbox.cpp
+++ b/src/tests/storage-rbox/it_test_read_mail_failed_rbox.cpp
@@ -14,7 +14,7 @@
 #include "TestCase.h"
 
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"           // turn off warnings for Dovecot :-(
+#pragma GCC diagnostic ignored "-Wshadow"           // turn off warnings for Dovecot   :-(
 #pragma GCC diagnostic ignored "-Wundef"            // turn off warnings for Dovecot :-(
 #pragma GCC diagnostic ignored "-Wredundant-decls"  // turn off warnings for Dovecot :-(
 #ifndef __cplusplus
@@ -117,6 +117,7 @@ TEST_F(StorageTest, read_mail_fails) {
 
     int ret2 = mail_get_stream(mail, &hdr_size, &body_size, &input);
     EXPECT_EQ(ret2, -1);
+    EXPECT_TRUE(mail->expunged);
     break;
   }
 
@@ -131,8 +132,6 @@ TEST_F(StorageTest, read_mail_fails) {
   if (mailbox_sync(box, static_cast<mailbox_sync_flags>(0)) < 0) {
     FAIL() << "sync failed";
   }
-
-  ASSERT_EQ(0, (int)box->index->map->hdr.messages_count);
 
   mailbox_free(&box);
 }


### PR DESCRIPTION
If a mail object is missing in object store (ENOENT), the index will no longer be marked as corrupted, which triggers a complete index rebuild (very slow). The Mail object will in this case always mark the mails as expunged. The index entry, if necessary, will be removed in sync.